### PR TITLE
Set units enum singular value - Fix #29

### DIFF
--- a/generator-scripts/src/unit-generator.ts
+++ b/generator-scripts/src/unit-generator.ts
@@ -37,6 +37,7 @@ function buildEnum(enumName: string, units: UnitProperties[]): EnumDeclarationSt
         members: units.map((unit: UnitProperties): EnumMemberStructure => ({
             kind: StructureKind.EnumMember,
             name: unit.pluralName,
+            value: unit.singularName,
             docs: [unit.JSDoc ?? '']
         })),
         isExported: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unitsnet-js",
-  "version": "1.0.130",
+  "version": "2.0.0",
   "description": "A better way to hold unit variables and easily convert to the destination unit",
   "scripts": {
     "prepublishOnly": "npm run generate && npm run test",

--- a/src/absorbeddoseofionizingradiation.g.ts
+++ b/src/absorbeddoseofionizingradiation.g.ts
@@ -1,37 +1,37 @@
 /** AbsorbedDoseOfIonizingRadiationUnits enumeration */
 export enum AbsorbedDoseOfIonizingRadiationUnits {
     /** The gray is the unit of ionizing radiation dose in the SI, defined as the absorption of one joule of radiation energy per kilogram of matter. */
-    Grays,
+    Grays = "Gray",
     /** The rad is a unit of absorbed radiation dose, defined as 1 rad = 0.01 Gy = 0.01 J/kg. */
-    Rads,
+    Rads = "Rad",
     /** */
-    Femtograys,
+    Femtograys = "Femtogray",
     /** */
-    Picograys,
+    Picograys = "Picogray",
     /** */
-    Nanograys,
+    Nanograys = "Nanogray",
     /** */
-    Micrograys,
+    Micrograys = "Microgray",
     /** */
-    Milligrays,
+    Milligrays = "Milligray",
     /** */
-    Centigrays,
+    Centigrays = "Centigray",
     /** */
-    Kilograys,
+    Kilograys = "Kilogray",
     /** */
-    Megagrays,
+    Megagrays = "Megagray",
     /** */
-    Gigagrays,
+    Gigagrays = "Gigagray",
     /** */
-    Teragrays,
+    Teragrays = "Teragray",
     /** */
-    Petagrays,
+    Petagrays = "Petagray",
     /** */
-    Millirads,
+    Millirads = "Millirad",
     /** */
-    Kilorads,
+    Kilorads = "Kilorad",
     /** */
-    Megarads
+    Megarads = "Megarad"
 }
 
 /** Absorbed dose is a dose quantity which is the measure of the energy deposited in matter by ionizing radiation per unit mass. */

--- a/src/acceleration.g.ts
+++ b/src/acceleration.g.ts
@@ -1,33 +1,33 @@
 /** AccelerationUnits enumeration */
 export enum AccelerationUnits {
     /** */
-    MetersPerSecondSquared,
+    MetersPerSecondSquared = "MeterPerSecondSquared",
     /** */
-    InchesPerSecondSquared,
+    InchesPerSecondSquared = "InchPerSecondSquared",
     /** */
-    FeetPerSecondSquared,
+    FeetPerSecondSquared = "FootPerSecondSquared",
     /** */
-    KnotsPerSecond,
+    KnotsPerSecond = "KnotPerSecond",
     /** */
-    KnotsPerMinute,
+    KnotsPerMinute = "KnotPerMinute",
     /** */
-    KnotsPerHour,
+    KnotsPerHour = "KnotPerHour",
     /** */
-    StandardGravity,
+    StandardGravity = "StandardGravity",
     /** */
-    NanometersPerSecondSquared,
+    NanometersPerSecondSquared = "NanometerPerSecondSquared",
     /** */
-    MicrometersPerSecondSquared,
+    MicrometersPerSecondSquared = "MicrometerPerSecondSquared",
     /** */
-    MillimetersPerSecondSquared,
+    MillimetersPerSecondSquared = "MillimeterPerSecondSquared",
     /** */
-    CentimetersPerSecondSquared,
+    CentimetersPerSecondSquared = "CentimeterPerSecondSquared",
     /** */
-    DecimetersPerSecondSquared,
+    DecimetersPerSecondSquared = "DecimeterPerSecondSquared",
     /** */
-    KilometersPerSecondSquared,
+    KilometersPerSecondSquared = "KilometerPerSecondSquared",
     /** */
-    MillistandardGravity
+    MillistandardGravity = "MillistandardGravity"
 }
 
 /** Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s²). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration. */

--- a/src/amountofsubstance.g.ts
+++ b/src/amountofsubstance.g.ts
@@ -1,39 +1,39 @@
 /** AmountOfSubstanceUnits enumeration */
 export enum AmountOfSubstanceUnits {
     /** */
-    Moles,
+    Moles = "Mole",
     /** */
-    PoundMoles,
+    PoundMoles = "PoundMole",
     /** */
-    Femtomoles,
+    Femtomoles = "Femtomole",
     /** */
-    Picomoles,
+    Picomoles = "Picomole",
     /** */
-    Nanomoles,
+    Nanomoles = "Nanomole",
     /** */
-    Micromoles,
+    Micromoles = "Micromole",
     /** */
-    Millimoles,
+    Millimoles = "Millimole",
     /** */
-    Centimoles,
+    Centimoles = "Centimole",
     /** */
-    Decimoles,
+    Decimoles = "Decimole",
     /** */
-    Kilomoles,
+    Kilomoles = "Kilomole",
     /** */
-    Megamoles,
+    Megamoles = "Megamole",
     /** */
-    NanopoundMoles,
+    NanopoundMoles = "NanopoundMole",
     /** */
-    MicropoundMoles,
+    MicropoundMoles = "MicropoundMole",
     /** */
-    MillipoundMoles,
+    MillipoundMoles = "MillipoundMole",
     /** */
-    CentipoundMoles,
+    CentipoundMoles = "CentipoundMole",
     /** */
-    DecipoundMoles,
+    DecipoundMoles = "DecipoundMole",
     /** */
-    KilopoundMoles
+    KilopoundMoles = "KilopoundMole"
 }
 
 /** Mole is the amount of substance containing Avagadro's Number (6.02 x 10 ^ 23) of real particles such as molecules,atoms, ions or radicals. */

--- a/src/amplituderatio.g.ts
+++ b/src/amplituderatio.g.ts
@@ -1,13 +1,13 @@
 /** AmplitudeRatioUnits enumeration */
 export enum AmplitudeRatioUnits {
     /** */
-    DecibelVolts,
+    DecibelVolts = "DecibelVolt",
     /** */
-    DecibelMicrovolts,
+    DecibelMicrovolts = "DecibelMicrovolt",
     /** */
-    DecibelMillivolts,
+    DecibelMillivolts = "DecibelMillivolt",
     /** */
-    DecibelsUnloaded
+    DecibelsUnloaded = "DecibelUnloaded"
 }
 
 /** The strength of a signal expressed in decibels (dB) relative to one volt RMS. */

--- a/src/angle.g.ts
+++ b/src/angle.g.ts
@@ -1,37 +1,37 @@
 /** AngleUnits enumeration */
 export enum AngleUnits {
     /** */
-    Radians,
+    Radians = "Radian",
     /** */
-    Degrees,
+    Degrees = "Degree",
     /** */
-    Arcminutes,
+    Arcminutes = "Arcminute",
     /** */
-    Arcseconds,
+    Arcseconds = "Arcsecond",
     /** */
-    Gradians,
+    Gradians = "Gradian",
     /** */
-    NatoMils,
+    NatoMils = "NatoMil",
     /** */
-    Revolutions,
+    Revolutions = "Revolution",
     /** */
-    Tilt,
+    Tilt = "Tilt",
     /** */
-    Nanoradians,
+    Nanoradians = "Nanoradian",
     /** */
-    Microradians,
+    Microradians = "Microradian",
     /** */
-    Milliradians,
+    Milliradians = "Milliradian",
     /** */
-    Centiradians,
+    Centiradians = "Centiradian",
     /** */
-    Deciradians,
+    Deciradians = "Deciradian",
     /** */
-    Nanodegrees,
+    Nanodegrees = "Nanodegree",
     /** */
-    Microdegrees,
+    Microdegrees = "Microdegree",
     /** */
-    Millidegrees
+    Millidegrees = "Millidegree"
 }
 
 /** In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle. */

--- a/src/apparentenergy.g.ts
+++ b/src/apparentenergy.g.ts
@@ -1,11 +1,11 @@
 /** ApparentEnergyUnits enumeration */
 export enum ApparentEnergyUnits {
     /** */
-    VoltampereHours,
+    VoltampereHours = "VoltampereHour",
     /** */
-    KilovoltampereHours,
+    KilovoltampereHours = "KilovoltampereHour",
     /** */
-    MegavoltampereHours
+    MegavoltampereHours = "MegavoltampereHour"
 }
 
 /** A unit for expressing the integral of apparent power over time, equal to the product of 1 volt-ampere and 1 hour, or to 3600 joules. */

--- a/src/apparentpower.g.ts
+++ b/src/apparentpower.g.ts
@@ -1,17 +1,17 @@
 /** ApparentPowerUnits enumeration */
 export enum ApparentPowerUnits {
     /** */
-    Voltamperes,
+    Voltamperes = "Voltampere",
     /** */
-    Microvoltamperes,
+    Microvoltamperes = "Microvoltampere",
     /** */
-    Millivoltamperes,
+    Millivoltamperes = "Millivoltampere",
     /** */
-    Kilovoltamperes,
+    Kilovoltamperes = "Kilovoltampere",
     /** */
-    Megavoltamperes,
+    Megavoltamperes = "Megavoltampere",
     /** */
-    Gigavoltamperes
+    Gigavoltamperes = "Gigavoltampere"
 }
 
 /** Power engineers measure apparent power as the magnitude of the vector sum of active and reactive power. Apparent power is the product of the root-mean-square of voltage and current. */

--- a/src/area.g.ts
+++ b/src/area.g.ts
@@ -1,33 +1,33 @@
 /** AreaUnits enumeration */
 export enum AreaUnits {
     /** */
-    SquareKilometers,
+    SquareKilometers = "SquareKilometer",
     /** */
-    SquareMeters,
+    SquareMeters = "SquareMeter",
     /** */
-    SquareDecimeters,
+    SquareDecimeters = "SquareDecimeter",
     /** */
-    SquareCentimeters,
+    SquareCentimeters = "SquareCentimeter",
     /** */
-    SquareMillimeters,
+    SquareMillimeters = "SquareMillimeter",
     /** */
-    SquareMicrometers,
+    SquareMicrometers = "SquareMicrometer",
     /** The statute mile was standardised between the British Commonwealth and the United States by an international agreement in 1959, when it was formally redefined with respect to SI units as exactly 1,609.344 metres. */
-    SquareMiles,
+    SquareMiles = "SquareMile",
     /** The yard (symbol: yd) is an English unit of length in both the British imperial and US customary systems of measurement equalling 3 feet (or 36 inches). Since 1959 the yard has been by international agreement standardized as exactly 0.9144 meter. A distance of 1,760 yards is equal to 1 mile. */
-    SquareYards,
+    SquareYards = "SquareYard",
     /** */
-    SquareFeet,
+    SquareFeet = "SquareFoot",
     /** In the United States, the foot was defined as 12 inches, with the inch being defined by the Mendenhall Order of 1893 as 39.37 inches = 1 m. This makes a U.S. survey foot exactly 1200/3937 meters. */
-    UsSurveySquareFeet,
+    UsSurveySquareFeet = "UsSurveySquareFoot",
     /** */
-    SquareInches,
+    SquareInches = "SquareInch",
     /** Based upon the international yard and pound agreement of 1959, an acre may be declared as exactly 4,046.8564224 square metres. */
-    Acres,
+    Acres = "Acre",
     /** */
-    Hectares,
+    Hectares = "Hectare",
     /** */
-    SquareNauticalMiles
+    SquareNauticalMiles = "SquareNauticalMile"
 }
 
 /** Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept). */

--- a/src/areadensity.g.ts
+++ b/src/areadensity.g.ts
@@ -1,11 +1,11 @@
 /** AreaDensityUnits enumeration */
 export enum AreaDensityUnits {
     /** */
-    KilogramsPerSquareMeter,
+    KilogramsPerSquareMeter = "KilogramPerSquareMeter",
     /** Also known as grammage for paper industry. In fiber industry used with abbreviation 'gsm'. */
-    GramsPerSquareMeter,
+    GramsPerSquareMeter = "GramPerSquareMeter",
     /** */
-    MilligramsPerSquareMeter
+    MilligramsPerSquareMeter = "MilligramPerSquareMeter"
 }
 
 /** The area density of a two-dimensional object is calculated as the mass per unit area. For paper this is also called grammage. */

--- a/src/areamomentofinertia.g.ts
+++ b/src/areamomentofinertia.g.ts
@@ -1,17 +1,17 @@
 /** AreaMomentOfInertiaUnits enumeration */
 export enum AreaMomentOfInertiaUnits {
     /** */
-    MetersToTheFourth,
+    MetersToTheFourth = "MeterToTheFourth",
     /** */
-    DecimetersToTheFourth,
+    DecimetersToTheFourth = "DecimeterToTheFourth",
     /** */
-    CentimetersToTheFourth,
+    CentimetersToTheFourth = "CentimeterToTheFourth",
     /** */
-    MillimetersToTheFourth,
+    MillimetersToTheFourth = "MillimeterToTheFourth",
     /** */
-    FeetToTheFourth,
+    FeetToTheFourth = "FootToTheFourth",
     /** */
-    InchesToTheFourth
+    InchesToTheFourth = "InchToTheFourth"
 }
 
 /** A geometric property of an area that reflects how its points are distributed with regard to an axis. */

--- a/src/bitrate.g.ts
+++ b/src/bitrate.g.ts
@@ -1,33 +1,33 @@
 /** BitRateUnits enumeration */
 export enum BitRateUnits {
     /** */
-    BitsPerSecond,
+    BitsPerSecond = "BitPerSecond",
     /** */
-    BytesPerSecond,
+    BytesPerSecond = "BytePerSecond",
     /** */
-    KilobitsPerSecond,
+    KilobitsPerSecond = "KilobitPerSecond",
     /** */
-    MegabitsPerSecond,
+    MegabitsPerSecond = "MegabitPerSecond",
     /** */
-    GigabitsPerSecond,
+    GigabitsPerSecond = "GigabitPerSecond",
     /** */
-    TerabitsPerSecond,
+    TerabitsPerSecond = "TerabitPerSecond",
     /** */
-    PetabitsPerSecond,
+    PetabitsPerSecond = "PetabitPerSecond",
     /** */
-    ExabitsPerSecond,
+    ExabitsPerSecond = "ExabitPerSecond",
     /** */
-    KilobytesPerSecond,
+    KilobytesPerSecond = "KilobytePerSecond",
     /** */
-    MegabytesPerSecond,
+    MegabytesPerSecond = "MegabytePerSecond",
     /** */
-    GigabytesPerSecond,
+    GigabytesPerSecond = "GigabytePerSecond",
     /** */
-    TerabytesPerSecond,
+    TerabytesPerSecond = "TerabytePerSecond",
     /** */
-    PetabytesPerSecond,
+    PetabytesPerSecond = "PetabytePerSecond",
     /** */
-    ExabytesPerSecond
+    ExabytesPerSecond = "ExabytePerSecond"
 }
 
 /** In telecommunications and computing, bit rate is the number of bits that are conveyed or processed per unit of time. */

--- a/src/brakespecificfuelconsumption.g.ts
+++ b/src/brakespecificfuelconsumption.g.ts
@@ -1,11 +1,11 @@
 /** BrakeSpecificFuelConsumptionUnits enumeration */
 export enum BrakeSpecificFuelConsumptionUnits {
     /** */
-    GramsPerKiloWattHour,
+    GramsPerKiloWattHour = "GramPerKiloWattHour",
     /** */
-    KilogramsPerJoule,
+    KilogramsPerJoule = "KilogramPerJoule",
     /** The pound per horse power hour uses mechanical horse power and the imperial pound */
-    PoundsPerMechanicalHorsepowerHour
+    PoundsPerMechanicalHorsepowerHour = "PoundPerMechanicalHorsepowerHour"
 }
 
 /** Brake specific fuel consumption (BSFC) is a measure of the fuel efficiency of any prime mover that burns fuel and produces rotational, or shaft, power. It is typically used for comparing the efficiency of internal combustion engines with a shaft output. */

--- a/src/capacitance.g.ts
+++ b/src/capacitance.g.ts
@@ -1,19 +1,19 @@
 /** CapacitanceUnits enumeration */
 export enum CapacitanceUnits {
     /** */
-    Farads,
+    Farads = "Farad",
     /** */
-    Picofarads,
+    Picofarads = "Picofarad",
     /** */
-    Nanofarads,
+    Nanofarads = "Nanofarad",
     /** */
-    Microfarads,
+    Microfarads = "Microfarad",
     /** */
-    Millifarads,
+    Millifarads = "Millifarad",
     /** */
-    Kilofarads,
+    Kilofarads = "Kilofarad",
     /** */
-    Megafarads
+    Megafarads = "Megafarad"
 }
 
 /** Capacitance is the ability of a body to store an electric charge. */

--- a/src/coefficientofthermalexpansion.g.ts
+++ b/src/coefficientofthermalexpansion.g.ts
@@ -1,17 +1,17 @@
 /** CoefficientOfThermalExpansionUnits enumeration */
 export enum CoefficientOfThermalExpansionUnits {
     /** */
-    PerKelvin,
+    PerKelvin = "PerKelvin",
     /** */
-    PerDegreeCelsius,
+    PerDegreeCelsius = "PerDegreeCelsius",
     /** */
-    PerDegreeFahrenheit,
+    PerDegreeFahrenheit = "PerDegreeFahrenheit",
     /** */
-    PpmPerKelvin,
+    PpmPerKelvin = "PpmPerKelvin",
     /** */
-    PpmPerDegreeCelsius,
+    PpmPerDegreeCelsius = "PpmPerDegreeCelsius",
     /** */
-    PpmPerDegreeFahrenheit
+    PpmPerDegreeFahrenheit = "PpmPerDegreeFahrenheit"
 }
 
 /** A unit that represents a fractional change in size in response to a change in temperature. */

--- a/src/compressibility.g.ts
+++ b/src/compressibility.g.ts
@@ -1,19 +1,19 @@
 /** CompressibilityUnits enumeration */
 export enum CompressibilityUnits {
     /** */
-    InversePascals,
+    InversePascals = "InversePascal",
     /** */
-    InverseKilopascals,
+    InverseKilopascals = "InverseKilopascal",
     /** */
-    InverseMegapascals,
+    InverseMegapascals = "InverseMegapascal",
     /** */
-    InverseAtmospheres,
+    InverseAtmospheres = "InverseAtmosphere",
     /** */
-    InverseMillibars,
+    InverseMillibars = "InverseMillibar",
     /** */
-    InverseBars,
+    InverseBars = "InverseBar",
     /** */
-    InversePoundsForcePerSquareInch
+    InversePoundsForcePerSquareInch = "InversePoundForcePerSquareInch"
 }
 
 /** Compressibility is the measure of the relative volume change of a fluid or solid in response to pressure changes. */

--- a/src/density.g.ts
+++ b/src/density.g.ts
@@ -1,117 +1,117 @@
 /** DensityUnits enumeration */
 export enum DensityUnits {
     /** */
-    GramsPerCubicMillimeter,
+    GramsPerCubicMillimeter = "GramPerCubicMillimeter",
     /** */
-    GramsPerCubicCentimeter,
+    GramsPerCubicCentimeter = "GramPerCubicCentimeter",
     /** */
-    GramsPerCubicMeter,
+    GramsPerCubicMeter = "GramPerCubicMeter",
     /** */
-    PoundsPerCubicInch,
+    PoundsPerCubicInch = "PoundPerCubicInch",
     /** */
-    PoundsPerCubicFoot,
+    PoundsPerCubicFoot = "PoundPerCubicFoot",
     /** Calculated from the definition of <a href="https://en.wikipedia.org/wiki/Pound_(mass)">pound</a> and <a href="https://en.wikipedia.org/wiki/Yard">yard</a> compared to metric kilogram and meter. */
-    PoundsPerCubicYard,
+    PoundsPerCubicYard = "PoundPerCubicYard",
     /** */
-    TonnesPerCubicMillimeter,
+    TonnesPerCubicMillimeter = "TonnePerCubicMillimeter",
     /** */
-    TonnesPerCubicCentimeter,
+    TonnesPerCubicCentimeter = "TonnePerCubicCentimeter",
     /** */
-    TonnesPerCubicMeter,
+    TonnesPerCubicMeter = "TonnePerCubicMeter",
     /** */
-    SlugsPerCubicFoot,
+    SlugsPerCubicFoot = "SlugPerCubicFoot",
     /** */
-    GramsPerLiter,
+    GramsPerLiter = "GramPerLiter",
     /** */
-    GramsPerDeciLiter,
+    GramsPerDeciLiter = "GramPerDeciliter",
     /** */
-    GramsPerMilliliter,
+    GramsPerMilliliter = "GramPerMilliliter",
     /** */
-    PoundsPerUSGallon,
+    PoundsPerUSGallon = "PoundPerUSGallon",
     /** */
-    PoundsPerImperialGallon,
+    PoundsPerImperialGallon = "PoundPerImperialGallon",
     /** */
-    KilogramsPerLiter,
+    KilogramsPerLiter = "KilogramPerLiter",
     /** */
-    TonnesPerCubicFoot,
+    TonnesPerCubicFoot = "TonnePerCubicFoot",
     /** */
-    TonnesPerCubicInch,
+    TonnesPerCubicInch = "TonnePerCubicInch",
     /** */
-    GramsPerCubicFoot,
+    GramsPerCubicFoot = "GramPerCubicFoot",
     /** */
-    GramsPerCubicInch,
+    GramsPerCubicInch = "GramPerCubicInch",
     /** */
-    PoundsPerCubicMeter,
+    PoundsPerCubicMeter = "PoundPerCubicMeter",
     /** */
-    PoundsPerCubicCentimeter,
+    PoundsPerCubicCentimeter = "PoundPerCubicCentimeter",
     /** */
-    PoundsPerCubicMillimeter,
+    PoundsPerCubicMillimeter = "PoundPerCubicMillimeter",
     /** */
-    SlugsPerCubicMeter,
+    SlugsPerCubicMeter = "SlugPerCubicMeter",
     /** */
-    SlugsPerCubicCentimeter,
+    SlugsPerCubicCentimeter = "SlugPerCubicCentimeter",
     /** */
-    SlugsPerCubicMillimeter,
+    SlugsPerCubicMillimeter = "SlugPerCubicMillimeter",
     /** */
-    SlugsPerCubicInch,
+    SlugsPerCubicInch = "SlugPerCubicInch",
     /** */
-    KilogramsPerCubicMillimeter,
+    KilogramsPerCubicMillimeter = "KilogramPerCubicMillimeter",
     /** */
-    KilogramsPerCubicCentimeter,
+    KilogramsPerCubicCentimeter = "KilogramPerCubicCentimeter",
     /** */
-    KilogramsPerCubicMeter,
+    KilogramsPerCubicMeter = "KilogramPerCubicMeter",
     /** */
-    MilligramsPerCubicMeter,
+    MilligramsPerCubicMeter = "MilligramPerCubicMeter",
     /** */
-    MicrogramsPerCubicMeter,
+    MicrogramsPerCubicMeter = "MicrogramPerCubicMeter",
     /** */
-    KilopoundsPerCubicInch,
+    KilopoundsPerCubicInch = "KilopoundPerCubicInch",
     /** */
-    KilopoundsPerCubicFoot,
+    KilopoundsPerCubicFoot = "KilopoundPerCubicFoot",
     /** */
-    KilopoundsPerCubicYard,
+    KilopoundsPerCubicYard = "KilopoundPerCubicYard",
     /** */
-    FemtogramsPerLiter,
+    FemtogramsPerLiter = "FemtogramPerLiter",
     /** */
-    PicogramsPerLiter,
+    PicogramsPerLiter = "PicogramPerLiter",
     /** */
-    NanogramsPerLiter,
+    NanogramsPerLiter = "NanogramPerLiter",
     /** */
-    MicrogramsPerLiter,
+    MicrogramsPerLiter = "MicrogramPerLiter",
     /** */
-    MilligramsPerLiter,
+    MilligramsPerLiter = "MilligramPerLiter",
     /** */
-    CentigramsPerLiter,
+    CentigramsPerLiter = "CentigramPerLiter",
     /** */
-    DecigramsPerLiter,
+    DecigramsPerLiter = "DecigramPerLiter",
     /** */
-    FemtogramsPerDeciLiter,
+    FemtogramsPerDeciLiter = "FemtogramPerDeciliter",
     /** */
-    PicogramsPerDeciLiter,
+    PicogramsPerDeciLiter = "PicogramPerDeciliter",
     /** */
-    NanogramsPerDeciLiter,
+    NanogramsPerDeciLiter = "NanogramPerDeciliter",
     /** */
-    MicrogramsPerDeciLiter,
+    MicrogramsPerDeciLiter = "MicrogramPerDeciliter",
     /** */
-    MilligramsPerDeciLiter,
+    MilligramsPerDeciLiter = "MilligramPerDeciliter",
     /** */
-    CentigramsPerDeciLiter,
+    CentigramsPerDeciLiter = "CentigramPerDeciliter",
     /** */
-    DecigramsPerDeciLiter,
+    DecigramsPerDeciLiter = "DecigramPerDeciliter",
     /** */
-    FemtogramsPerMilliliter,
+    FemtogramsPerMilliliter = "FemtogramPerMilliliter",
     /** */
-    PicogramsPerMilliliter,
+    PicogramsPerMilliliter = "PicogramPerMilliliter",
     /** */
-    NanogramsPerMilliliter,
+    NanogramsPerMilliliter = "NanogramPerMilliliter",
     /** */
-    MicrogramsPerMilliliter,
+    MicrogramsPerMilliliter = "MicrogramPerMilliliter",
     /** */
-    MilligramsPerMilliliter,
+    MilligramsPerMilliliter = "MilligramPerMilliliter",
     /** */
-    CentigramsPerMilliliter,
+    CentigramsPerMilliliter = "CentigramPerMilliliter",
     /** */
-    DecigramsPerMilliliter
+    DecigramsPerMilliliter = "DecigramPerMilliliter"
 }
 
 /** The density, or more precisely, the volumetric mass density, of a substance is its mass per unit volume. */

--- a/src/duration.g.ts
+++ b/src/duration.g.ts
@@ -1,27 +1,27 @@
 /** DurationUnits enumeration */
 export enum DurationUnits {
     /** */
-    Years365,
+    Years365 = "Year365",
     /** */
-    Months30,
+    Months30 = "Month30",
     /** */
-    Weeks,
+    Weeks = "Week",
     /** */
-    Days,
+    Days = "Day",
     /** */
-    Hours,
+    Hours = "Hour",
     /** */
-    Minutes,
+    Minutes = "Minute",
     /** */
-    Seconds,
+    Seconds = "Second",
     /** */
-    JulianYears,
+    JulianYears = "JulianYear",
     /** */
-    Nanoseconds,
+    Nanoseconds = "Nanosecond",
     /** */
-    Microseconds,
+    Microseconds = "Microsecond",
     /** */
-    Milliseconds
+    Milliseconds = "Millisecond"
 }
 
 /** Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them. */

--- a/src/dynamicviscosity.g.ts
+++ b/src/dynamicviscosity.g.ts
@@ -1,25 +1,25 @@
 /** DynamicViscosityUnits enumeration */
 export enum DynamicViscosityUnits {
     /** */
-    NewtonSecondsPerMeterSquared,
+    NewtonSecondsPerMeterSquared = "NewtonSecondPerMeterSquared",
     /** */
-    PascalSeconds,
+    PascalSeconds = "PascalSecond",
     /** */
-    Poise,
+    Poise = "Poise",
     /** */
-    Reyns,
+    Reyns = "Reyn",
     /** */
-    PoundsForceSecondPerSquareInch,
+    PoundsForceSecondPerSquareInch = "PoundForceSecondPerSquareInch",
     /** */
-    PoundsForceSecondPerSquareFoot,
+    PoundsForceSecondPerSquareFoot = "PoundForceSecondPerSquareFoot",
     /** */
-    PoundsPerFootSecond,
+    PoundsPerFootSecond = "PoundPerFootSecond",
     /** */
-    MillipascalSeconds,
+    MillipascalSeconds = "MillipascalSecond",
     /** */
-    MicropascalSeconds,
+    MicropascalSeconds = "MicropascalSecond",
     /** */
-    Centipoise
+    Centipoise = "Centipoise"
 }
 
 /** The dynamic (shear) viscosity of a fluid expresses its resistance to shearing flows, where adjacent layers move parallel to each other with different speeds */

--- a/src/electricadmittance.g.ts
+++ b/src/electricadmittance.g.ts
@@ -1,13 +1,13 @@
 /** ElectricAdmittanceUnits enumeration */
 export enum ElectricAdmittanceUnits {
     /** */
-    Siemens,
+    Siemens = "Siemens",
     /** */
-    Nanosiemens,
+    Nanosiemens = "Nanosiemens",
     /** */
-    Microsiemens,
+    Microsiemens = "Microsiemens",
     /** */
-    Millisiemens
+    Millisiemens = "Millisiemens"
 }
 
 /** Electric admittance is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of impedance. The SI unit of admittance is the siemens (symbol S). */

--- a/src/electriccharge.g.ts
+++ b/src/electriccharge.g.ts
@@ -1,27 +1,27 @@
 /** ElectricChargeUnits enumeration */
 export enum ElectricChargeUnits {
     /** */
-    Coulombs,
+    Coulombs = "Coulomb",
     /** */
-    AmpereHours,
+    AmpereHours = "AmpereHour",
     /** */
-    Picocoulombs,
+    Picocoulombs = "Picocoulomb",
     /** */
-    Nanocoulombs,
+    Nanocoulombs = "Nanocoulomb",
     /** */
-    Microcoulombs,
+    Microcoulombs = "Microcoulomb",
     /** */
-    Millicoulombs,
+    Millicoulombs = "Millicoulomb",
     /** */
-    Kilocoulombs,
+    Kilocoulombs = "Kilocoulomb",
     /** */
-    Megacoulombs,
+    Megacoulombs = "Megacoulomb",
     /** */
-    MilliampereHours,
+    MilliampereHours = "MilliampereHour",
     /** */
-    KiloampereHours,
+    KiloampereHours = "KiloampereHour",
     /** */
-    MegaampereHours
+    MegaampereHours = "MegaampereHour"
 }
 
 /** Electric charge is the physical property of matter that causes it to experience a force when placed in an electromagnetic field. */

--- a/src/electricchargedensity.g.ts
+++ b/src/electricchargedensity.g.ts
@@ -1,7 +1,7 @@
 /** ElectricChargeDensityUnits enumeration */
 export enum ElectricChargeDensityUnits {
     /** */
-    CoulombsPerCubicMeter
+    CoulombsPerCubicMeter = "CoulombPerCubicMeter"
 }
 
 /** In electromagnetism, charge density is a measure of the amount of electric charge per volume. */

--- a/src/electricconductance.g.ts
+++ b/src/electricconductance.g.ts
@@ -1,15 +1,15 @@
 /** ElectricConductanceUnits enumeration */
 export enum ElectricConductanceUnits {
     /** */
-    Siemens,
+    Siemens = "Siemens",
     /** */
-    Nanosiemens,
+    Nanosiemens = "Nanosiemens",
     /** */
-    Microsiemens,
+    Microsiemens = "Microsiemens",
     /** */
-    Millisiemens,
+    Millisiemens = "Millisiemens",
     /** */
-    Kilosiemens
+    Kilosiemens = "Kilosiemens"
 }
 
 /** The electrical conductance of an electrical conductor is a measure of the easeness to pass an electric current through that conductor. */

--- a/src/electricconductivity.g.ts
+++ b/src/electricconductivity.g.ts
@@ -1,17 +1,17 @@
 /** ElectricConductivityUnits enumeration */
 export enum ElectricConductivityUnits {
     /** */
-    SiemensPerMeter,
+    SiemensPerMeter = "SiemensPerMeter",
     /** */
-    SiemensPerInch,
+    SiemensPerInch = "SiemensPerInch",
     /** */
-    SiemensPerFoot,
+    SiemensPerFoot = "SiemensPerFoot",
     /** */
-    SiemensPerCentimeter,
+    SiemensPerCentimeter = "SiemensPerCentimeter",
     /** */
-    MicrosiemensPerCentimeter,
+    MicrosiemensPerCentimeter = "MicrosiemensPerCentimeter",
     /** */
-    MillisiemensPerCentimeter
+    MillisiemensPerCentimeter = "MillisiemensPerCentimeter"
 }
 
 /** Electrical conductivity or specific conductance is the reciprocal of electrical resistivity, and measures a material's ability to conduct an electric current. */

--- a/src/electriccurrent.g.ts
+++ b/src/electriccurrent.g.ts
@@ -1,23 +1,23 @@
 /** ElectricCurrentUnits enumeration */
 export enum ElectricCurrentUnits {
     /** */
-    Amperes,
+    Amperes = "Ampere",
     /** */
-    Femtoamperes,
+    Femtoamperes = "Femtoampere",
     /** */
-    Picoamperes,
+    Picoamperes = "Picoampere",
     /** */
-    Nanoamperes,
+    Nanoamperes = "Nanoampere",
     /** */
-    Microamperes,
+    Microamperes = "Microampere",
     /** */
-    Milliamperes,
+    Milliamperes = "Milliampere",
     /** */
-    Centiamperes,
+    Centiamperes = "Centiampere",
     /** */
-    Kiloamperes,
+    Kiloamperes = "Kiloampere",
     /** */
-    Megaamperes
+    Megaamperes = "Megaampere"
 }
 
 /** An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma. */

--- a/src/electriccurrentdensity.g.ts
+++ b/src/electriccurrentdensity.g.ts
@@ -1,11 +1,11 @@
 /** ElectricCurrentDensityUnits enumeration */
 export enum ElectricCurrentDensityUnits {
     /** */
-    AmperesPerSquareMeter,
+    AmperesPerSquareMeter = "AmperePerSquareMeter",
     /** */
-    AmperesPerSquareInch,
+    AmperesPerSquareInch = "AmperePerSquareInch",
     /** */
-    AmperesPerSquareFoot
+    AmperesPerSquareFoot = "AmperePerSquareFoot"
 }
 
 /** In electromagnetism, current density is the electric current per unit area of cross section. */

--- a/src/electriccurrentgradient.g.ts
+++ b/src/electriccurrentgradient.g.ts
@@ -1,19 +1,19 @@
 /** ElectricCurrentGradientUnits enumeration */
 export enum ElectricCurrentGradientUnits {
     /** */
-    AmperesPerSecond,
+    AmperesPerSecond = "AmperePerSecond",
     /** */
-    AmperesPerMinute,
+    AmperesPerMinute = "AmperePerMinute",
     /** */
-    AmperesPerMillisecond,
+    AmperesPerMillisecond = "AmperePerMillisecond",
     /** */
-    AmperesPerMicrosecond,
+    AmperesPerMicrosecond = "AmperePerMicrosecond",
     /** */
-    AmperesPerNanosecond,
+    AmperesPerNanosecond = "AmperePerNanosecond",
     /** */
-    MilliamperesPerSecond,
+    MilliamperesPerSecond = "MilliamperePerSecond",
     /** */
-    MilliamperesPerMinute
+    MilliamperesPerMinute = "MilliamperePerMinute"
 }
 
 /** In electromagnetism, the current gradient describes how the current changes in time. */

--- a/src/electricfield.g.ts
+++ b/src/electricfield.g.ts
@@ -1,7 +1,7 @@
 /** ElectricFieldUnits enumeration */
 export enum ElectricFieldUnits {
     /** */
-    VoltsPerMeter
+    VoltsPerMeter = "VoltPerMeter"
 }
 
 /** An electric field is a force field that surrounds electric charges that attracts or repels other electric charges. */

--- a/src/electricinductance.g.ts
+++ b/src/electricinductance.g.ts
@@ -1,15 +1,15 @@
 /** ElectricInductanceUnits enumeration */
 export enum ElectricInductanceUnits {
     /** */
-    Henries,
+    Henries = "Henry",
     /** */
-    Picohenries,
+    Picohenries = "Picohenry",
     /** */
-    Nanohenries,
+    Nanohenries = "Nanohenry",
     /** */
-    Microhenries,
+    Microhenries = "Microhenry",
     /** */
-    Millihenries
+    Millihenries = "Millihenry"
 }
 
 /** Inductance is a property of an electrical conductor which opposes a change in current. */

--- a/src/electricpotential.g.ts
+++ b/src/electricpotential.g.ts
@@ -1,17 +1,17 @@
 /** ElectricPotentialUnits enumeration */
 export enum ElectricPotentialUnits {
     /** */
-    Volts,
+    Volts = "Volt",
     /** */
-    Nanovolts,
+    Nanovolts = "Nanovolt",
     /** */
-    Microvolts,
+    Microvolts = "Microvolt",
     /** */
-    Millivolts,
+    Millivolts = "Millivolt",
     /** */
-    Kilovolts,
+    Kilovolts = "Kilovolt",
     /** */
-    Megavolts
+    Megavolts = "Megavolt"
 }
 
 /** In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point. */

--- a/src/electricpotentialac.g.ts
+++ b/src/electricpotentialac.g.ts
@@ -1,15 +1,15 @@
 /** ElectricPotentialAcUnits enumeration */
 export enum ElectricPotentialAcUnits {
     /** */
-    VoltsAc,
+    VoltsAc = "VoltAc",
     /** */
-    MicrovoltsAc,
+    MicrovoltsAc = "MicrovoltAc",
     /** */
-    MillivoltsAc,
+    MillivoltsAc = "MillivoltAc",
     /** */
-    KilovoltsAc,
+    KilovoltsAc = "KilovoltAc",
     /** */
-    MegavoltsAc
+    MegavoltsAc = "MegavoltAc"
 }
 
 /** The Electric Potential of a system known to use Alternating Current. */

--- a/src/electricpotentialchangerate.g.ts
+++ b/src/electricpotentialchangerate.g.ts
@@ -1,45 +1,45 @@
 /** ElectricPotentialChangeRateUnits enumeration */
 export enum ElectricPotentialChangeRateUnits {
     /** */
-    VoltsPerSeconds,
+    VoltsPerSeconds = "VoltPerSecond",
     /** */
-    VoltsPerMicroseconds,
+    VoltsPerMicroseconds = "VoltPerMicrosecond",
     /** */
-    VoltsPerMinutes,
+    VoltsPerMinutes = "VoltPerMinute",
     /** */
-    VoltsPerHours,
+    VoltsPerHours = "VoltPerHour",
     /** */
-    MicrovoltsPerSeconds,
+    MicrovoltsPerSeconds = "MicrovoltPerSecond",
     /** */
-    MillivoltsPerSeconds,
+    MillivoltsPerSeconds = "MillivoltPerSecond",
     /** */
-    KilovoltsPerSeconds,
+    KilovoltsPerSeconds = "KilovoltPerSecond",
     /** */
-    MegavoltsPerSeconds,
+    MegavoltsPerSeconds = "MegavoltPerSecond",
     /** */
-    MicrovoltsPerMicroseconds,
+    MicrovoltsPerMicroseconds = "MicrovoltPerMicrosecond",
     /** */
-    MillivoltsPerMicroseconds,
+    MillivoltsPerMicroseconds = "MillivoltPerMicrosecond",
     /** */
-    KilovoltsPerMicroseconds,
+    KilovoltsPerMicroseconds = "KilovoltPerMicrosecond",
     /** */
-    MegavoltsPerMicroseconds,
+    MegavoltsPerMicroseconds = "MegavoltPerMicrosecond",
     /** */
-    MicrovoltsPerMinutes,
+    MicrovoltsPerMinutes = "MicrovoltPerMinute",
     /** */
-    MillivoltsPerMinutes,
+    MillivoltsPerMinutes = "MillivoltPerMinute",
     /** */
-    KilovoltsPerMinutes,
+    KilovoltsPerMinutes = "KilovoltPerMinute",
     /** */
-    MegavoltsPerMinutes,
+    MegavoltsPerMinutes = "MegavoltPerMinute",
     /** */
-    MicrovoltsPerHours,
+    MicrovoltsPerHours = "MicrovoltPerHour",
     /** */
-    MillivoltsPerHours,
+    MillivoltsPerHours = "MillivoltPerHour",
     /** */
-    KilovoltsPerHours,
+    KilovoltsPerHours = "KilovoltPerHour",
     /** */
-    MegavoltsPerHours
+    MegavoltsPerHours = "MegavoltPerHour"
 }
 
 /** ElectricPotential change rate is the ratio of the electric potential change to the time during which the change occurred (value of electric potential changes per unit time). */

--- a/src/electricpotentialdc.g.ts
+++ b/src/electricpotentialdc.g.ts
@@ -1,15 +1,15 @@
 /** ElectricPotentialDcUnits enumeration */
 export enum ElectricPotentialDcUnits {
     /** */
-    VoltsDc,
+    VoltsDc = "VoltDc",
     /** */
-    MicrovoltsDc,
+    MicrovoltsDc = "MicrovoltDc",
     /** */
-    MillivoltsDc,
+    MillivoltsDc = "MillivoltDc",
     /** */
-    KilovoltsDc,
+    KilovoltsDc = "KilovoltDc",
     /** */
-    MegavoltsDc
+    MegavoltsDc = "MegavoltDc"
 }
 
 /** The Electric Potential of a system known to use Direct Current. */

--- a/src/electricresistance.g.ts
+++ b/src/electricresistance.g.ts
@@ -1,19 +1,19 @@
 /** ElectricResistanceUnits enumeration */
 export enum ElectricResistanceUnits {
     /** */
-    Ohms,
+    Ohms = "Ohm",
     /** */
-    Microohms,
+    Microohms = "Microohm",
     /** */
-    Milliohms,
+    Milliohms = "Milliohm",
     /** */
-    Kiloohms,
+    Kiloohms = "Kiloohm",
     /** */
-    Megaohms,
+    Megaohms = "Megaohm",
     /** */
-    Gigaohms,
+    Gigaohms = "Gigaohm",
     /** */
-    Teraohms
+    Teraohms = "Teraohm"
 }
 
 /** The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor. */

--- a/src/electricresistivity.g.ts
+++ b/src/electricresistivity.g.ts
@@ -1,33 +1,33 @@
 /** ElectricResistivityUnits enumeration */
 export enum ElectricResistivityUnits {
     /** */
-    OhmMeters,
+    OhmMeters = "OhmMeter",
     /** */
-    OhmsCentimeter,
+    OhmsCentimeter = "OhmCentimeter",
     /** */
-    PicoohmMeters,
+    PicoohmMeters = "PicoohmMeter",
     /** */
-    NanoohmMeters,
+    NanoohmMeters = "NanoohmMeter",
     /** */
-    MicroohmMeters,
+    MicroohmMeters = "MicroohmMeter",
     /** */
-    MilliohmMeters,
+    MilliohmMeters = "MilliohmMeter",
     /** */
-    KiloohmMeters,
+    KiloohmMeters = "KiloohmMeter",
     /** */
-    MegaohmMeters,
+    MegaohmMeters = "MegaohmMeter",
     /** */
-    PicoohmsCentimeter,
+    PicoohmsCentimeter = "PicoohmCentimeter",
     /** */
-    NanoohmsCentimeter,
+    NanoohmsCentimeter = "NanoohmCentimeter",
     /** */
-    MicroohmsCentimeter,
+    MicroohmsCentimeter = "MicroohmCentimeter",
     /** */
-    MilliohmsCentimeter,
+    MilliohmsCentimeter = "MilliohmCentimeter",
     /** */
-    KiloohmsCentimeter,
+    KiloohmsCentimeter = "KiloohmCentimeter",
     /** */
-    MegaohmsCentimeter
+    MegaohmsCentimeter = "MegaohmCentimeter"
 }
 
 /** Electrical resistivity (also known as resistivity, specific electrical resistance, or volume resistivity) is a fundamental property that quantifies how strongly a given material opposes the flow of electric current. */

--- a/src/electricsurfacechargedensity.g.ts
+++ b/src/electricsurfacechargedensity.g.ts
@@ -1,11 +1,11 @@
 /** ElectricSurfaceChargeDensityUnits enumeration */
 export enum ElectricSurfaceChargeDensityUnits {
     /** */
-    CoulombsPerSquareMeter,
+    CoulombsPerSquareMeter = "CoulombPerSquareMeter",
     /** */
-    CoulombsPerSquareCentimeter,
+    CoulombsPerSquareCentimeter = "CoulombPerSquareCentimeter",
     /** */
-    CoulombsPerSquareInch
+    CoulombsPerSquareInch = "CoulombPerSquareInch"
 }
 
 /** In electromagnetism, surface charge density is a measure of the amount of electric charge per surface area. */

--- a/src/energy.g.ts
+++ b/src/energy.g.ts
@@ -1,85 +1,85 @@
 /** EnergyUnits enumeration */
 export enum EnergyUnits {
     /** */
-    Joules,
+    Joules = "Joule",
     /** */
-    Calories,
+    Calories = "Calorie",
     /** */
-    BritishThermalUnits,
+    BritishThermalUnits = "BritishThermalUnit",
     /** */
-    ElectronVolts,
+    ElectronVolts = "ElectronVolt",
     /** */
-    FootPounds,
+    FootPounds = "FootPound",
     /** */
-    Ergs,
+    Ergs = "Erg",
     /** */
-    WattHours,
+    WattHours = "WattHour",
     /** */
-    WattDays,
+    WattDays = "WattDay",
     /** */
-    ThermsEc,
+    ThermsEc = "ThermEc",
     /** */
-    ThermsUs,
+    ThermsUs = "ThermUs",
     /** */
-    ThermsImperial,
+    ThermsImperial = "ThermImperial",
     /** */
-    HorsepowerHours,
+    HorsepowerHours = "HorsepowerHour",
     /** */
-    Nanojoules,
+    Nanojoules = "Nanojoule",
     /** */
-    Microjoules,
+    Microjoules = "Microjoule",
     /** */
-    Millijoules,
+    Millijoules = "Millijoule",
     /** */
-    Kilojoules,
+    Kilojoules = "Kilojoule",
     /** */
-    Megajoules,
+    Megajoules = "Megajoule",
     /** */
-    Gigajoules,
+    Gigajoules = "Gigajoule",
     /** */
-    Terajoules,
+    Terajoules = "Terajoule",
     /** */
-    Petajoules,
+    Petajoules = "Petajoule",
     /** */
-    Kilocalories,
+    Kilocalories = "Kilocalorie",
     /** */
-    Megacalories,
+    Megacalories = "Megacalorie",
     /** */
-    KilobritishThermalUnits,
+    KilobritishThermalUnits = "KilobritishThermalUnit",
     /** */
-    MegabritishThermalUnits,
+    MegabritishThermalUnits = "MegabritishThermalUnit",
     /** */
-    GigabritishThermalUnits,
+    GigabritishThermalUnits = "GigabritishThermalUnit",
     /** */
-    KiloelectronVolts,
+    KiloelectronVolts = "KiloelectronVolt",
     /** */
-    MegaelectronVolts,
+    MegaelectronVolts = "MegaelectronVolt",
     /** */
-    GigaelectronVolts,
+    GigaelectronVolts = "GigaelectronVolt",
     /** */
-    TeraelectronVolts,
+    TeraelectronVolts = "TeraelectronVolt",
     /** */
-    KilowattHours,
+    KilowattHours = "KilowattHour",
     /** */
-    MegawattHours,
+    MegawattHours = "MegawattHour",
     /** */
-    GigawattHours,
+    GigawattHours = "GigawattHour",
     /** */
-    TerawattHours,
+    TerawattHours = "TerawattHour",
     /** */
-    KilowattDays,
+    KilowattDays = "KilowattDay",
     /** */
-    MegawattDays,
+    MegawattDays = "MegawattDay",
     /** */
-    GigawattDays,
+    GigawattDays = "GigawattDay",
     /** */
-    TerawattDays,
+    TerawattDays = "TerawattDay",
     /** */
-    DecathermsEc,
+    DecathermsEc = "DecathermEc",
     /** */
-    DecathermsUs,
+    DecathermsUs = "DecathermUs",
     /** */
-    DecathermsImperial
+    DecathermsImperial = "DecathermImperial"
 }
 
 /** The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second. Many other units of energy are included. Please do not confuse this definition of the calorie with the one colloquially used by the food industry, the large calorie, which is equivalent to 1 kcal. Thermochemical definition of the calorie is used. For BTU, the IT definition is used. */

--- a/src/energydensity.g.ts
+++ b/src/energydensity.g.ts
@@ -1,29 +1,29 @@
 /** EnergyDensityUnits enumeration */
 export enum EnergyDensityUnits {
     /** */
-    JoulesPerCubicMeter,
+    JoulesPerCubicMeter = "JoulePerCubicMeter",
     /** */
-    WattHoursPerCubicMeter,
+    WattHoursPerCubicMeter = "WattHourPerCubicMeter",
     /** */
-    KilojoulesPerCubicMeter,
+    KilojoulesPerCubicMeter = "KilojoulePerCubicMeter",
     /** */
-    MegajoulesPerCubicMeter,
+    MegajoulesPerCubicMeter = "MegajoulePerCubicMeter",
     /** */
-    GigajoulesPerCubicMeter,
+    GigajoulesPerCubicMeter = "GigajoulePerCubicMeter",
     /** */
-    TerajoulesPerCubicMeter,
+    TerajoulesPerCubicMeter = "TerajoulePerCubicMeter",
     /** */
-    PetajoulesPerCubicMeter,
+    PetajoulesPerCubicMeter = "PetajoulePerCubicMeter",
     /** */
-    KilowattHoursPerCubicMeter,
+    KilowattHoursPerCubicMeter = "KilowattHourPerCubicMeter",
     /** */
-    MegawattHoursPerCubicMeter,
+    MegawattHoursPerCubicMeter = "MegawattHourPerCubicMeter",
     /** */
-    GigawattHoursPerCubicMeter,
+    GigawattHoursPerCubicMeter = "GigawattHourPerCubicMeter",
     /** */
-    TerawattHoursPerCubicMeter,
+    TerawattHoursPerCubicMeter = "TerawattHourPerCubicMeter",
     /** */
-    PetawattHoursPerCubicMeter
+    PetawattHoursPerCubicMeter = "PetawattHourPerCubicMeter"
 }
 
 /** Energy density is the amount of energy stored in a substance per unit volume and is measured in J/m³. It is sometimes confused with energy per unit mass which is properly called specific energy. */

--- a/src/entropy.g.ts
+++ b/src/entropy.g.ts
@@ -1,19 +1,19 @@
 /** EntropyUnits enumeration */
 export enum EntropyUnits {
     /** */
-    JoulesPerKelvin,
+    JoulesPerKelvin = "JoulePerKelvin",
     /** */
-    CaloriesPerKelvin,
+    CaloriesPerKelvin = "CaloriePerKelvin",
     /** */
-    JoulesPerDegreeCelsius,
+    JoulesPerDegreeCelsius = "JoulePerDegreeCelsius",
     /** */
-    KilojoulesPerKelvin,
+    KilojoulesPerKelvin = "KilojoulePerKelvin",
     /** */
-    MegajoulesPerKelvin,
+    MegajoulesPerKelvin = "MegajoulePerKelvin",
     /** */
-    KilocaloriesPerKelvin,
+    KilocaloriesPerKelvin = "KilocaloriePerKelvin",
     /** */
-    KilojoulesPerDegreeCelsius
+    KilojoulesPerDegreeCelsius = "KilojoulePerDegreeCelsius"
 }
 
 /** Entropy is an important concept in the branch of science known as thermodynamics. The idea of "irreversibility" is central to the understanding of entropy.  It is often said that entropy is an expression of the disorder, or randomness of a system, or of our lack of information about it. Entropy is an extensive property. It has the dimension of energy divided by temperature, which has a unit of joules per kelvin (J/K) in the International System of Units */

--- a/src/force.g.ts
+++ b/src/force.g.ts
@@ -1,35 +1,35 @@
 /** ForceUnits enumeration */
 export enum ForceUnits {
     /** One dyne is equal to 10 micronewtons, 10e−5 N or to 10 nsn (nanosthenes) in the old metre–tonne–second system of units. */
-    Dyne,
+    Dyne = "Dyn",
     /** The kilogram-force, or kilopond, is equal to the magnitude of the force exerted on one kilogram of mass in a 9.80665 m/s2 gravitational field (standard gravity). Therefore, one kilogram-force is by definition equal to 9.80665 N. */
-    KilogramsForce,
+    KilogramsForce = "KilogramForce",
     /** The tonne-force, metric ton-force, megagram-force, and megapond (Mp) are each 1000 kilograms-force. */
-    TonnesForce,
+    TonnesForce = "TonneForce",
     /** The newton (symbol: N) is the unit of force in the International System of Units (SI). It is defined as 1 kg⋅m/s2, the force which gives a mass of 1 kilogram an acceleration of 1 metre per second per second. */
-    Newtons,
+    Newtons = "Newton",
     /** The kilogram-force, or kilopond, is equal to the magnitude of the force exerted on one kilogram of mass in a 9.80665 m/s2 gravitational field (standard gravity). Therefore, one kilogram-force is by definition equal to 9.80665 N. */
-    KiloPonds,
+    KiloPonds = "KiloPond",
     /** The poundal is defined as the force necessary to accelerate 1 pound-mass at 1 foot per second per second. 1 pdl = 0.138254954376 N exactly. */
-    Poundals,
+    Poundals = "Poundal",
     /** The standard values of acceleration of the standard gravitational field (gn) and the international avoirdupois pound (lb) result in a pound-force equal to 4.4482216152605 N. */
-    PoundsForce,
+    PoundsForce = "PoundForce",
     /** An ounce-force is 1⁄16 of a pound-force, or about 0.2780139 newtons. */
-    OunceForce,
+    OunceForce = "OunceForce",
     /** The short ton-force is a unit of force equal to 2,000 pounds-force (907.18474 kgf), that is most commonly used in the United States – known there simply as the ton or US ton. */
-    ShortTonsForce,
+    ShortTonsForce = "ShortTonForce",
     /** */
-    Micronewtons,
+    Micronewtons = "Micronewton",
     /** */
-    Millinewtons,
+    Millinewtons = "Millinewton",
     /** */
-    Decanewtons,
+    Decanewtons = "Decanewton",
     /** */
-    Kilonewtons,
+    Kilonewtons = "Kilonewton",
     /** */
-    Meganewtons,
+    Meganewtons = "Meganewton",
     /** */
-    KilopoundsForce
+    KilopoundsForce = "KilopoundForce"
 }
 
 /** In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F. */

--- a/src/forcechangerate.g.ts
+++ b/src/forcechangerate.g.ts
@@ -1,35 +1,35 @@
 /** ForceChangeRateUnits enumeration */
 export enum ForceChangeRateUnits {
     /** */
-    NewtonsPerMinute,
+    NewtonsPerMinute = "NewtonPerMinute",
     /** */
-    NewtonsPerSecond,
+    NewtonsPerSecond = "NewtonPerSecond",
     /** */
-    PoundsForcePerMinute,
+    PoundsForcePerMinute = "PoundForcePerMinute",
     /** */
-    PoundsForcePerSecond,
+    PoundsForcePerSecond = "PoundForcePerSecond",
     /** */
-    DecanewtonsPerMinute,
+    DecanewtonsPerMinute = "DecanewtonPerMinute",
     /** */
-    KilonewtonsPerMinute,
+    KilonewtonsPerMinute = "KilonewtonPerMinute",
     /** */
-    NanonewtonsPerSecond,
+    NanonewtonsPerSecond = "NanonewtonPerSecond",
     /** */
-    MicronewtonsPerSecond,
+    MicronewtonsPerSecond = "MicronewtonPerSecond",
     /** */
-    MillinewtonsPerSecond,
+    MillinewtonsPerSecond = "MillinewtonPerSecond",
     /** */
-    CentinewtonsPerSecond,
+    CentinewtonsPerSecond = "CentinewtonPerSecond",
     /** */
-    DecinewtonsPerSecond,
+    DecinewtonsPerSecond = "DecinewtonPerSecond",
     /** */
-    DecanewtonsPerSecond,
+    DecanewtonsPerSecond = "DecanewtonPerSecond",
     /** */
-    KilonewtonsPerSecond,
+    KilonewtonsPerSecond = "KilonewtonPerSecond",
     /** */
-    KilopoundsForcePerMinute,
+    KilopoundsForcePerMinute = "KilopoundForcePerMinute",
     /** */
-    KilopoundsForcePerSecond
+    KilopoundsForcePerSecond = "KilopoundForcePerSecond"
 }
 
 /** Force change rate is the ratio of the force change to the time during which the change occurred (value of force changes per unit time). */

--- a/src/forceperlength.g.ts
+++ b/src/forceperlength.g.ts
@@ -1,81 +1,81 @@
 /** ForcePerLengthUnits enumeration */
 export enum ForcePerLengthUnits {
     /** */
-    NewtonsPerMeter,
+    NewtonsPerMeter = "NewtonPerMeter",
     /** */
-    NewtonsPerCentimeter,
+    NewtonsPerCentimeter = "NewtonPerCentimeter",
     /** */
-    NewtonsPerMillimeter,
+    NewtonsPerMillimeter = "NewtonPerMillimeter",
     /** */
-    KilogramsForcePerMeter,
+    KilogramsForcePerMeter = "KilogramForcePerMeter",
     /** */
-    KilogramsForcePerCentimeter,
+    KilogramsForcePerCentimeter = "KilogramForcePerCentimeter",
     /** */
-    KilogramsForcePerMillimeter,
+    KilogramsForcePerMillimeter = "KilogramForcePerMillimeter",
     /** */
-    TonnesForcePerMeter,
+    TonnesForcePerMeter = "TonneForcePerMeter",
     /** */
-    TonnesForcePerCentimeter,
+    TonnesForcePerCentimeter = "TonneForcePerCentimeter",
     /** */
-    TonnesForcePerMillimeter,
+    TonnesForcePerMillimeter = "TonneForcePerMillimeter",
     /** */
-    PoundsForcePerFoot,
+    PoundsForcePerFoot = "PoundForcePerFoot",
     /** */
-    PoundsForcePerInch,
+    PoundsForcePerInch = "PoundForcePerInch",
     /** */
-    PoundsForcePerYard,
+    PoundsForcePerYard = "PoundForcePerYard",
     /** */
-    KilopoundsForcePerFoot,
+    KilopoundsForcePerFoot = "KilopoundForcePerFoot",
     /** */
-    KilopoundsForcePerInch,
+    KilopoundsForcePerInch = "KilopoundForcePerInch",
     /** */
-    NanonewtonsPerMeter,
+    NanonewtonsPerMeter = "NanonewtonPerMeter",
     /** */
-    MicronewtonsPerMeter,
+    MicronewtonsPerMeter = "MicronewtonPerMeter",
     /** */
-    MillinewtonsPerMeter,
+    MillinewtonsPerMeter = "MillinewtonPerMeter",
     /** */
-    CentinewtonsPerMeter,
+    CentinewtonsPerMeter = "CentinewtonPerMeter",
     /** */
-    DecinewtonsPerMeter,
+    DecinewtonsPerMeter = "DecinewtonPerMeter",
     /** */
-    DecanewtonsPerMeter,
+    DecanewtonsPerMeter = "DecanewtonPerMeter",
     /** */
-    KilonewtonsPerMeter,
+    KilonewtonsPerMeter = "KilonewtonPerMeter",
     /** */
-    MeganewtonsPerMeter,
+    MeganewtonsPerMeter = "MeganewtonPerMeter",
     /** */
-    NanonewtonsPerCentimeter,
+    NanonewtonsPerCentimeter = "NanonewtonPerCentimeter",
     /** */
-    MicronewtonsPerCentimeter,
+    MicronewtonsPerCentimeter = "MicronewtonPerCentimeter",
     /** */
-    MillinewtonsPerCentimeter,
+    MillinewtonsPerCentimeter = "MillinewtonPerCentimeter",
     /** */
-    CentinewtonsPerCentimeter,
+    CentinewtonsPerCentimeter = "CentinewtonPerCentimeter",
     /** */
-    DecinewtonsPerCentimeter,
+    DecinewtonsPerCentimeter = "DecinewtonPerCentimeter",
     /** */
-    DecanewtonsPerCentimeter,
+    DecanewtonsPerCentimeter = "DecanewtonPerCentimeter",
     /** */
-    KilonewtonsPerCentimeter,
+    KilonewtonsPerCentimeter = "KilonewtonPerCentimeter",
     /** */
-    MeganewtonsPerCentimeter,
+    MeganewtonsPerCentimeter = "MeganewtonPerCentimeter",
     /** */
-    NanonewtonsPerMillimeter,
+    NanonewtonsPerMillimeter = "NanonewtonPerMillimeter",
     /** */
-    MicronewtonsPerMillimeter,
+    MicronewtonsPerMillimeter = "MicronewtonPerMillimeter",
     /** */
-    MillinewtonsPerMillimeter,
+    MillinewtonsPerMillimeter = "MillinewtonPerMillimeter",
     /** */
-    CentinewtonsPerMillimeter,
+    CentinewtonsPerMillimeter = "CentinewtonPerMillimeter",
     /** */
-    DecinewtonsPerMillimeter,
+    DecinewtonsPerMillimeter = "DecinewtonPerMillimeter",
     /** */
-    DecanewtonsPerMillimeter,
+    DecanewtonsPerMillimeter = "DecanewtonPerMillimeter",
     /** */
-    KilonewtonsPerMillimeter,
+    KilonewtonsPerMillimeter = "KilonewtonPerMillimeter",
     /** */
-    MeganewtonsPerMillimeter
+    MeganewtonsPerMillimeter = "MeganewtonPerMillimeter"
 }
 
 /** The magnitude of force per unit length. */

--- a/src/frequency.g.ts
+++ b/src/frequency.g.ts
@@ -1,31 +1,31 @@
 /** FrequencyUnits enumeration */
 export enum FrequencyUnits {
     /** */
-    Hertz,
+    Hertz = "Hertz",
     /** */
-    RadiansPerSecond,
+    RadiansPerSecond = "RadianPerSecond",
     /** */
-    CyclesPerMinute,
+    CyclesPerMinute = "CyclePerMinute",
     /** */
-    CyclesPerHour,
+    CyclesPerHour = "CyclePerHour",
     /** */
-    BeatsPerMinute,
+    BeatsPerMinute = "BeatPerMinute",
     /** */
-    PerSecond,
+    PerSecond = "PerSecond",
     /** */
-    BUnits,
+    BUnits = "BUnit",
     /** */
-    Microhertz,
+    Microhertz = "Microhertz",
     /** */
-    Millihertz,
+    Millihertz = "Millihertz",
     /** */
-    Kilohertz,
+    Kilohertz = "Kilohertz",
     /** */
-    Megahertz,
+    Megahertz = "Megahertz",
     /** */
-    Gigahertz,
+    Gigahertz = "Gigahertz",
     /** */
-    Terahertz
+    Terahertz = "Terahertz"
 }
 
 /** The number of occurrences of a repeating event per unit time. */

--- a/src/fuelefficiency.g.ts
+++ b/src/fuelefficiency.g.ts
@@ -1,13 +1,13 @@
 /** FuelEfficiencyUnits enumeration */
 export enum FuelEfficiencyUnits {
     /** */
-    LitersPer100Kilometers,
+    LitersPer100Kilometers = "LiterPer100Kilometers",
     /** */
-    MilesPerUsGallon,
+    MilesPerUsGallon = "MilePerUsGallon",
     /** */
-    MilesPerUkGallon,
+    MilesPerUkGallon = "MilePerUkGallon",
     /** */
-    KilometersPerLiters
+    KilometersPerLiters = "KilometerPerLiter"
 }
 
 /** Fuel efficiency is a form of thermal efficiency, meaning the ratio from effort to result of a process that converts chemical potential energy contained in a carrier (fuel) into kinetic energy or work. Fuel economy is stated as "fuel consumption" in liters per 100 kilometers (L/100 km). In countries using non-metric system, fuel economy is expressed in miles per gallon (mpg) (imperial galon or US galon). */

--- a/src/heatflux.g.ts
+++ b/src/heatflux.g.ts
@@ -1,41 +1,41 @@
 /** HeatFluxUnits enumeration */
 export enum HeatFluxUnits {
     /** */
-    WattsPerSquareMeter,
+    WattsPerSquareMeter = "WattPerSquareMeter",
     /** */
-    WattsPerSquareInch,
+    WattsPerSquareInch = "WattPerSquareInch",
     /** */
-    WattsPerSquareFoot,
+    WattsPerSquareFoot = "WattPerSquareFoot",
     /** */
-    BtusPerSecondSquareInch,
+    BtusPerSecondSquareInch = "BtuPerSecondSquareInch",
     /** */
-    BtusPerSecondSquareFoot,
+    BtusPerSecondSquareFoot = "BtuPerSecondSquareFoot",
     /** */
-    BtusPerMinuteSquareFoot,
+    BtusPerMinuteSquareFoot = "BtuPerMinuteSquareFoot",
     /** */
-    BtusPerHourSquareFoot,
+    BtusPerHourSquareFoot = "BtuPerHourSquareFoot",
     /** */
-    CaloriesPerSecondSquareCentimeter,
+    CaloriesPerSecondSquareCentimeter = "CaloriePerSecondSquareCentimeter",
     /** */
-    KilocaloriesPerHourSquareMeter,
+    KilocaloriesPerHourSquareMeter = "KilocaloriePerHourSquareMeter",
     /** */
-    PoundsForcePerFootSecond,
+    PoundsForcePerFootSecond = "PoundForcePerFootSecond",
     /** */
-    PoundsPerSecondCubed,
+    PoundsPerSecondCubed = "PoundPerSecondCubed",
     /** */
-    NanowattsPerSquareMeter,
+    NanowattsPerSquareMeter = "NanowattPerSquareMeter",
     /** */
-    MicrowattsPerSquareMeter,
+    MicrowattsPerSquareMeter = "MicrowattPerSquareMeter",
     /** */
-    MilliwattsPerSquareMeter,
+    MilliwattsPerSquareMeter = "MilliwattPerSquareMeter",
     /** */
-    CentiwattsPerSquareMeter,
+    CentiwattsPerSquareMeter = "CentiwattPerSquareMeter",
     /** */
-    DeciwattsPerSquareMeter,
+    DeciwattsPerSquareMeter = "DeciwattPerSquareMeter",
     /** */
-    KilowattsPerSquareMeter,
+    KilowattsPerSquareMeter = "KilowattPerSquareMeter",
     /** */
-    KilocaloriesPerSecondSquareCentimeter
+    KilocaloriesPerSecondSquareCentimeter = "KilocaloriePerSecondSquareCentimeter"
 }
 
 /** Heat flux is the flow of energy per unit of area per unit of time */

--- a/src/heattransfercoefficient.g.ts
+++ b/src/heattransfercoefficient.g.ts
@@ -1,15 +1,15 @@
 /** HeatTransferCoefficientUnits enumeration */
 export enum HeatTransferCoefficientUnits {
     /** */
-    WattsPerSquareMeterKelvin,
+    WattsPerSquareMeterKelvin = "WattPerSquareMeterKelvin",
     /** */
-    WattsPerSquareMeterCelsius,
+    WattsPerSquareMeterCelsius = "WattPerSquareMeterCelsius",
     /** */
-    BtusPerHourSquareFootDegreeFahrenheit,
+    BtusPerHourSquareFootDegreeFahrenheit = "BtuPerHourSquareFootDegreeFahrenheit",
     /** */
-    CaloriesPerHourSquareMeterDegreeCelsius,
+    CaloriesPerHourSquareMeterDegreeCelsius = "CaloriePerHourSquareMeterDegreeCelsius",
     /** */
-    KilocaloriesPerHourSquareMeterDegreeCelsius
+    KilocaloriesPerHourSquareMeterDegreeCelsius = "KilocaloriePerHourSquareMeterDegreeCelsius"
 }
 
 /** The heat transfer coefficient or film coefficient, or film effectiveness, in thermodynamics and in mechanics is the proportionality constant between the heat flux and the thermodynamic driving force for the flow of heat (i.e., the temperature difference, ΔT) */

--- a/src/illuminance.g.ts
+++ b/src/illuminance.g.ts
@@ -1,13 +1,13 @@
 /** IlluminanceUnits enumeration */
 export enum IlluminanceUnits {
     /** */
-    Lux,
+    Lux = "Lux",
     /** */
-    Millilux,
+    Millilux = "Millilux",
     /** */
-    Kilolux,
+    Kilolux = "Kilolux",
     /** */
-    Megalux
+    Megalux = "Megalux"
 }
 
 /** In photometry, illuminance is the total luminous flux incident on a surface, per unit area. */

--- a/src/impulse.g.ts
+++ b/src/impulse.g.ts
@@ -1,31 +1,31 @@
 /** ImpulseUnits enumeration */
 export enum ImpulseUnits {
     /** */
-    KilogramMetersPerSecond,
+    KilogramMetersPerSecond = "KilogramMeterPerSecond",
     /** */
-    NewtonSeconds,
+    NewtonSeconds = "NewtonSecond",
     /** */
-    PoundFeetPerSecond,
+    PoundFeetPerSecond = "PoundFootPerSecond",
     /** */
-    PoundForceSeconds,
+    PoundForceSeconds = "PoundForceSecond",
     /** */
-    SlugFeetPerSecond,
+    SlugFeetPerSecond = "SlugFootPerSecond",
     /** */
-    NanonewtonSeconds,
+    NanonewtonSeconds = "NanonewtonSecond",
     /** */
-    MicronewtonSeconds,
+    MicronewtonSeconds = "MicronewtonSecond",
     /** */
-    MillinewtonSeconds,
+    MillinewtonSeconds = "MillinewtonSecond",
     /** */
-    CentinewtonSeconds,
+    CentinewtonSeconds = "CentinewtonSecond",
     /** */
-    DecinewtonSeconds,
+    DecinewtonSeconds = "DecinewtonSecond",
     /** */
-    DecanewtonSeconds,
+    DecanewtonSeconds = "DecanewtonSecond",
     /** */
-    KilonewtonSeconds,
+    KilonewtonSeconds = "KilonewtonSecond",
     /** */
-    MeganewtonSeconds
+    MeganewtonSeconds = "MeganewtonSecond"
 }
 
 /** In classical mechanics, impulse is the integral of a force, F, over the time interval, t, for which it acts. Impulse applied to an object produces an equivalent vector change in its linear momentum, also in the resultant direction. */

--- a/src/information.g.ts
+++ b/src/information.g.ts
@@ -1,33 +1,33 @@
 /** InformationUnits enumeration */
 export enum InformationUnits {
     /** */
-    Bytes,
+    Bytes = "Byte",
     /** */
-    Bits,
+    Bits = "Bit",
     /** */
-    Kilobytes,
+    Kilobytes = "Kilobyte",
     /** */
-    Megabytes,
+    Megabytes = "Megabyte",
     /** */
-    Gigabytes,
+    Gigabytes = "Gigabyte",
     /** */
-    Terabytes,
+    Terabytes = "Terabyte",
     /** */
-    Petabytes,
+    Petabytes = "Petabyte",
     /** */
-    Exabytes,
+    Exabytes = "Exabyte",
     /** */
-    Kilobits,
+    Kilobits = "Kilobit",
     /** */
-    Megabits,
+    Megabits = "Megabit",
     /** */
-    Gigabits,
+    Gigabits = "Gigabit",
     /** */
-    Terabits,
+    Terabits = "Terabit",
     /** */
-    Petabits,
+    Petabits = "Petabit",
     /** */
-    Exabits
+    Exabits = "Exabit"
 }
 
 /** In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables. */

--- a/src/irradiance.g.ts
+++ b/src/irradiance.g.ts
@@ -1,33 +1,33 @@
 /** IrradianceUnits enumeration */
 export enum IrradianceUnits {
     /** */
-    WattsPerSquareMeter,
+    WattsPerSquareMeter = "WattPerSquareMeter",
     /** */
-    WattsPerSquareCentimeter,
+    WattsPerSquareCentimeter = "WattPerSquareCentimeter",
     /** */
-    PicowattsPerSquareMeter,
+    PicowattsPerSquareMeter = "PicowattPerSquareMeter",
     /** */
-    NanowattsPerSquareMeter,
+    NanowattsPerSquareMeter = "NanowattPerSquareMeter",
     /** */
-    MicrowattsPerSquareMeter,
+    MicrowattsPerSquareMeter = "MicrowattPerSquareMeter",
     /** */
-    MilliwattsPerSquareMeter,
+    MilliwattsPerSquareMeter = "MilliwattPerSquareMeter",
     /** */
-    KilowattsPerSquareMeter,
+    KilowattsPerSquareMeter = "KilowattPerSquareMeter",
     /** */
-    MegawattsPerSquareMeter,
+    MegawattsPerSquareMeter = "MegawattPerSquareMeter",
     /** */
-    PicowattsPerSquareCentimeter,
+    PicowattsPerSquareCentimeter = "PicowattPerSquareCentimeter",
     /** */
-    NanowattsPerSquareCentimeter,
+    NanowattsPerSquareCentimeter = "NanowattPerSquareCentimeter",
     /** */
-    MicrowattsPerSquareCentimeter,
+    MicrowattsPerSquareCentimeter = "MicrowattPerSquareCentimeter",
     /** */
-    MilliwattsPerSquareCentimeter,
+    MilliwattsPerSquareCentimeter = "MilliwattPerSquareCentimeter",
     /** */
-    KilowattsPerSquareCentimeter,
+    KilowattsPerSquareCentimeter = "KilowattPerSquareCentimeter",
     /** */
-    MegawattsPerSquareCentimeter
+    MegawattsPerSquareCentimeter = "MegawattPerSquareCentimeter"
 }
 
 /** Irradiance is the intensity of ultraviolet (UV) or visible light incident on a surface. */

--- a/src/irradiation.g.ts
+++ b/src/irradiation.g.ts
@@ -1,23 +1,23 @@
 /** IrradiationUnits enumeration */
 export enum IrradiationUnits {
     /** */
-    JoulesPerSquareMeter,
+    JoulesPerSquareMeter = "JoulePerSquareMeter",
     /** */
-    JoulesPerSquareCentimeter,
+    JoulesPerSquareCentimeter = "JoulePerSquareCentimeter",
     /** */
-    JoulesPerSquareMillimeter,
+    JoulesPerSquareMillimeter = "JoulePerSquareMillimeter",
     /** */
-    WattHoursPerSquareMeter,
+    WattHoursPerSquareMeter = "WattHourPerSquareMeter",
     /** */
-    BtusPerSquareFoot,
+    BtusPerSquareFoot = "BtuPerSquareFoot",
     /** */
-    KilojoulesPerSquareMeter,
+    KilojoulesPerSquareMeter = "KilojoulePerSquareMeter",
     /** */
-    MillijoulesPerSquareCentimeter,
+    MillijoulesPerSquareCentimeter = "MillijoulePerSquareCentimeter",
     /** */
-    KilowattHoursPerSquareMeter,
+    KilowattHoursPerSquareMeter = "KilowattHourPerSquareMeter",
     /** */
-    KilobtusPerSquareFoot
+    KilobtusPerSquareFoot = "KilobtuPerSquareFoot"
 }
 
 /** Irradiation is the process by which an object is exposed to radiation. The exposure can originate from various sources, including natural sources. */

--- a/src/jerk.g.ts
+++ b/src/jerk.g.ts
@@ -1,27 +1,27 @@
 /** JerkUnits enumeration */
 export enum JerkUnits {
     /** */
-    MetersPerSecondCubed,
+    MetersPerSecondCubed = "MeterPerSecondCubed",
     /** */
-    InchesPerSecondCubed,
+    InchesPerSecondCubed = "InchPerSecondCubed",
     /** */
-    FeetPerSecondCubed,
+    FeetPerSecondCubed = "FootPerSecondCubed",
     /** */
-    StandardGravitiesPerSecond,
+    StandardGravitiesPerSecond = "StandardGravitiesPerSecond",
     /** */
-    NanometersPerSecondCubed,
+    NanometersPerSecondCubed = "NanometerPerSecondCubed",
     /** */
-    MicrometersPerSecondCubed,
+    MicrometersPerSecondCubed = "MicrometerPerSecondCubed",
     /** */
-    MillimetersPerSecondCubed,
+    MillimetersPerSecondCubed = "MillimeterPerSecondCubed",
     /** */
-    CentimetersPerSecondCubed,
+    CentimetersPerSecondCubed = "CentimeterPerSecondCubed",
     /** */
-    DecimetersPerSecondCubed,
+    DecimetersPerSecondCubed = "DecimeterPerSecondCubed",
     /** */
-    KilometersPerSecondCubed,
+    KilometersPerSecondCubed = "KilometerPerSecondCubed",
     /** */
-    MillistandardGravitiesPerSecond
+    MillistandardGravitiesPerSecond = "MillistandardGravitiesPerSecond"
 }
 
 /** Jerk or Jolt, in physics, is the rate at which the acceleration of an object changes over time. The SI unit for jerk is the Meter per second cubed (m/s³). Jerks are vector quantities (they have magnitude and direction) and add according to the parallelogram law. */

--- a/src/kinematicviscosity.g.ts
+++ b/src/kinematicviscosity.g.ts
@@ -1,23 +1,23 @@
 /** KinematicViscosityUnits enumeration */
 export enum KinematicViscosityUnits {
     /** */
-    SquareMetersPerSecond,
+    SquareMetersPerSecond = "SquareMeterPerSecond",
     /** */
-    Stokes,
+    Stokes = "Stokes",
     /** */
-    SquareFeetPerSecond,
+    SquareFeetPerSecond = "SquareFootPerSecond",
     /** */
-    Nanostokes,
+    Nanostokes = "Nanostokes",
     /** */
-    Microstokes,
+    Microstokes = "Microstokes",
     /** */
-    Millistokes,
+    Millistokes = "Millistokes",
     /** */
-    Centistokes,
+    Centistokes = "Centistokes",
     /** */
-    Decistokes,
+    Decistokes = "Decistokes",
     /** */
-    Kilostokes
+    Kilostokes = "Kilostokes"
 }
 
 /** The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress. */

--- a/src/leakrate.g.ts
+++ b/src/leakrate.g.ts
@@ -1,11 +1,11 @@
 /** LeakRateUnits enumeration */
 export enum LeakRateUnits {
     /** */
-    PascalCubicMetersPerSecond,
+    PascalCubicMetersPerSecond = "PascalCubicMeterPerSecond",
     /** */
-    MillibarLitersPerSecond,
+    MillibarLitersPerSecond = "MillibarLiterPerSecond",
     /** */
-    TorrLitersPerSecond
+    TorrLitersPerSecond = "TorrLiterPerSecond"
 }
 
 /** A leakage rate of QL = 1 Pa-m³/s is given when the pressure in a closed, evacuated container with a volume of 1 m³ rises by 1 Pa per second or when the pressure in the container drops by 1 Pa in the event of overpressure. */

--- a/src/length.g.ts
+++ b/src/length.g.ts
@@ -1,89 +1,89 @@
 /** LengthUnits enumeration */
 export enum LengthUnits {
     /** */
-    Meters,
+    Meters = "Meter",
     /** The statute mile was standardised between the British Commonwealth and the United States by an international agreement in 1959, when it was formally redefined with respect to SI units as exactly 1,609.344 metres. */
-    Miles,
+    Miles = "Mile",
     /** The yard (symbol: yd) is an English unit of length in both the British imperial and US customary systems of measurement equalling 3 feet (or 36 inches). Since 1959 the yard has been by international agreement standardized as exactly 0.9144 meter. A distance of 1,760 yards is equal to 1 mile. */
-    Yards,
+    Yards = "Yard",
     /** */
-    Feet,
+    Feet = "Foot",
     /** In the United States, the foot was defined as 12 inches, with the inch being defined by the Mendenhall Order of 1893 as 39.37 inches = 1 m. This makes a U.S. survey foot exactly 1200/3937 meters. */
-    UsSurveyFeet,
+    UsSurveyFeet = "UsSurveyFoot",
     /** */
-    Inches,
+    Inches = "Inch",
     /** */
-    Mils,
+    Mils = "Mil",
     /** */
-    NauticalMiles,
+    NauticalMiles = "NauticalMile",
     /** */
-    Fathoms,
+    Fathoms = "Fathom",
     /** */
-    Shackles,
+    Shackles = "Shackle",
     /** */
-    Microinches,
+    Microinches = "Microinch",
     /** */
-    PrinterPoints,
+    PrinterPoints = "PrinterPoint",
     /** */
-    DtpPoints,
+    DtpPoints = "DtpPoint",
     /** */
-    PrinterPicas,
+    PrinterPicas = "PrinterPica",
     /** */
-    DtpPicas,
+    DtpPicas = "DtpPica",
     /** */
-    Twips,
+    Twips = "Twip",
     /** */
-    Hands,
+    Hands = "Hand",
     /** One Astronomical Unit is the distance from the solar system Star, the sun, to planet Earth. */
-    AstronomicalUnits,
+    AstronomicalUnits = "AstronomicalUnit",
     /** A parsec is defined as the distance at which one astronomical unit (AU) subtends an angle of one arcsecond. */
-    Parsecs,
+    Parsecs = "Parsec",
     /** A Light Year (ly) is the distance that light travel during an Earth year, ie 365 days. */
-    LightYears,
+    LightYears = "LightYear",
     /** Solar radius is a ratio unit to the radius of the solar system star, the sun. */
-    SolarRadiuses,
+    SolarRadiuses = "SolarRadius",
     /** */
-    Chains,
+    Chains = "Chain",
     /** Angstrom is a metric unit of length equal to 1e-10 meter */
-    Angstroms,
+    Angstroms = "Angstrom",
     /** In radar-related subjects and in JTIDS, a data mile is a unit of distance equal to 6000 feet (1.8288 kilometres or 0.987 nautical miles). */
-    DataMiles,
+    DataMiles = "DataMile",
     /** */
-    Femtometers,
+    Femtometers = "Femtometer",
     /** */
-    Picometers,
+    Picometers = "Picometer",
     /** */
-    Nanometers,
+    Nanometers = "Nanometer",
     /** */
-    Micrometers,
+    Micrometers = "Micrometer",
     /** */
-    Millimeters,
+    Millimeters = "Millimeter",
     /** */
-    Centimeters,
+    Centimeters = "Centimeter",
     /** */
-    Decimeters,
+    Decimeters = "Decimeter",
     /** */
-    Decameters,
+    Decameters = "Decameter",
     /** */
-    Hectometers,
+    Hectometers = "Hectometer",
     /** */
-    Kilometers,
+    Kilometers = "Kilometer",
     /** */
-    Megameters,
+    Megameters = "Megameter",
     /** */
-    Gigameters,
+    Gigameters = "Gigameter",
     /** */
-    Kiloyards,
+    Kiloyards = "Kiloyard",
     /** */
-    Kilofeet,
+    Kilofeet = "Kilofoot",
     /** */
-    Kiloparsecs,
+    Kiloparsecs = "Kiloparsec",
     /** */
-    Megaparsecs,
+    Megaparsecs = "Megaparsec",
     /** */
-    KilolightYears,
+    KilolightYears = "KilolightYear",
     /** */
-    MegalightYears
+    MegalightYears = "MegalightYear"
 }
 
 /** Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units. */

--- a/src/level.g.ts
+++ b/src/level.g.ts
@@ -1,9 +1,9 @@
 /** LevelUnits enumeration */
 export enum LevelUnits {
     /** */
-    Decibels,
+    Decibels = "Decibel",
     /** */
-    Nepers
+    Nepers = "Neper"
 }
 
 /** Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q₀, expressed in dimensionless units. */

--- a/src/lineardensity.g.ts
+++ b/src/lineardensity.g.ts
@@ -1,33 +1,33 @@
 /** LinearDensityUnits enumeration */
 export enum LinearDensityUnits {
     /** */
-    GramsPerMillimeter,
+    GramsPerMillimeter = "GramPerMillimeter",
     /** */
-    GramsPerCentimeter,
+    GramsPerCentimeter = "GramPerCentimeter",
     /** */
-    GramsPerMeter,
+    GramsPerMeter = "GramPerMeter",
     /** */
-    PoundsPerInch,
+    PoundsPerInch = "PoundPerInch",
     /** */
-    PoundsPerFoot,
+    PoundsPerFoot = "PoundPerFoot",
     /** */
-    MicrogramsPerMillimeter,
+    MicrogramsPerMillimeter = "MicrogramPerMillimeter",
     /** */
-    MilligramsPerMillimeter,
+    MilligramsPerMillimeter = "MilligramPerMillimeter",
     /** */
-    KilogramsPerMillimeter,
+    KilogramsPerMillimeter = "KilogramPerMillimeter",
     /** */
-    MicrogramsPerCentimeter,
+    MicrogramsPerCentimeter = "MicrogramPerCentimeter",
     /** */
-    MilligramsPerCentimeter,
+    MilligramsPerCentimeter = "MilligramPerCentimeter",
     /** */
-    KilogramsPerCentimeter,
+    KilogramsPerCentimeter = "KilogramPerCentimeter",
     /** */
-    MicrogramsPerMeter,
+    MicrogramsPerMeter = "MicrogramPerMeter",
     /** */
-    MilligramsPerMeter,
+    MilligramsPerMeter = "MilligramPerMeter",
     /** */
-    KilogramsPerMeter
+    KilogramsPerMeter = "KilogramPerMeter"
 }
 
 /** The Linear Density, or more precisely, the linear mass density, of a substance is its mass per unit length.  The term linear density is most often used when describing the characteristics of one-dimensional objects, although linear density can also be used to describe the density of a three-dimensional quantity along one particular dimension. */

--- a/src/linearpowerdensity.g.ts
+++ b/src/linearpowerdensity.g.ts
@@ -1,55 +1,55 @@
 /** LinearPowerDensityUnits enumeration */
 export enum LinearPowerDensityUnits {
     /** */
-    WattsPerMeter,
+    WattsPerMeter = "WattPerMeter",
     /** */
-    WattsPerCentimeter,
+    WattsPerCentimeter = "WattPerCentimeter",
     /** */
-    WattsPerMillimeter,
+    WattsPerMillimeter = "WattPerMillimeter",
     /** */
-    WattsPerInch,
+    WattsPerInch = "WattPerInch",
     /** */
-    WattsPerFoot,
+    WattsPerFoot = "WattPerFoot",
     /** */
-    MilliwattsPerMeter,
+    MilliwattsPerMeter = "MilliwattPerMeter",
     /** */
-    KilowattsPerMeter,
+    KilowattsPerMeter = "KilowattPerMeter",
     /** */
-    MegawattsPerMeter,
+    MegawattsPerMeter = "MegawattPerMeter",
     /** */
-    GigawattsPerMeter,
+    GigawattsPerMeter = "GigawattPerMeter",
     /** */
-    MilliwattsPerCentimeter,
+    MilliwattsPerCentimeter = "MilliwattPerCentimeter",
     /** */
-    KilowattsPerCentimeter,
+    KilowattsPerCentimeter = "KilowattPerCentimeter",
     /** */
-    MegawattsPerCentimeter,
+    MegawattsPerCentimeter = "MegawattPerCentimeter",
     /** */
-    GigawattsPerCentimeter,
+    GigawattsPerCentimeter = "GigawattPerCentimeter",
     /** */
-    MilliwattsPerMillimeter,
+    MilliwattsPerMillimeter = "MilliwattPerMillimeter",
     /** */
-    KilowattsPerMillimeter,
+    KilowattsPerMillimeter = "KilowattPerMillimeter",
     /** */
-    MegawattsPerMillimeter,
+    MegawattsPerMillimeter = "MegawattPerMillimeter",
     /** */
-    GigawattsPerMillimeter,
+    GigawattsPerMillimeter = "GigawattPerMillimeter",
     /** */
-    MilliwattsPerInch,
+    MilliwattsPerInch = "MilliwattPerInch",
     /** */
-    KilowattsPerInch,
+    KilowattsPerInch = "KilowattPerInch",
     /** */
-    MegawattsPerInch,
+    MegawattsPerInch = "MegawattPerInch",
     /** */
-    GigawattsPerInch,
+    GigawattsPerInch = "GigawattPerInch",
     /** */
-    MilliwattsPerFoot,
+    MilliwattsPerFoot = "MilliwattPerFoot",
     /** */
-    KilowattsPerFoot,
+    KilowattsPerFoot = "KilowattPerFoot",
     /** */
-    MegawattsPerFoot,
+    MegawattsPerFoot = "MegawattPerFoot",
     /** */
-    GigawattsPerFoot
+    GigawattsPerFoot = "GigawattPerFoot"
 }
 
 /** The Linear Power Density of a substance is its power per unit length.  The term linear density is most often used when describing the characteristics of one-dimensional objects, although linear density can also be used to describe the density of a three-dimensional quantity along one particular dimension. */

--- a/src/luminance.g.ts
+++ b/src/luminance.g.ts
@@ -1,25 +1,25 @@
 /** LuminanceUnits enumeration */
 export enum LuminanceUnits {
     /** */
-    CandelasPerSquareMeter,
+    CandelasPerSquareMeter = "CandelaPerSquareMeter",
     /** */
-    CandelasPerSquareFoot,
+    CandelasPerSquareFoot = "CandelaPerSquareFoot",
     /** */
-    CandelasPerSquareInch,
+    CandelasPerSquareInch = "CandelaPerSquareInch",
     /** */
-    Nits,
+    Nits = "Nit",
     /** */
-    NanocandelasPerSquareMeter,
+    NanocandelasPerSquareMeter = "NanocandelaPerSquareMeter",
     /** */
-    MicrocandelasPerSquareMeter,
+    MicrocandelasPerSquareMeter = "MicrocandelaPerSquareMeter",
     /** */
-    MillicandelasPerSquareMeter,
+    MillicandelasPerSquareMeter = "MillicandelaPerSquareMeter",
     /** */
-    CenticandelasPerSquareMeter,
+    CenticandelasPerSquareMeter = "CenticandelaPerSquareMeter",
     /** */
-    DecicandelasPerSquareMeter,
+    DecicandelasPerSquareMeter = "DecicandelaPerSquareMeter",
     /** */
-    KilocandelasPerSquareMeter
+    KilocandelasPerSquareMeter = "KilocandelaPerSquareMeter"
 }
 
 /** Luminance is a photometric measure of the luminous intensity per unit area of light travelling in a given direction. */

--- a/src/luminosity.g.ts
+++ b/src/luminosity.g.ts
@@ -1,33 +1,33 @@
 /** LuminosityUnits enumeration */
 export enum LuminosityUnits {
     /** */
-    Watts,
+    Watts = "Watt",
     /** */
-    SolarLuminosities,
+    SolarLuminosities = "SolarLuminosity",
     /** */
-    Femtowatts,
+    Femtowatts = "Femtowatt",
     /** */
-    Picowatts,
+    Picowatts = "Picowatt",
     /** */
-    Nanowatts,
+    Nanowatts = "Nanowatt",
     /** */
-    Microwatts,
+    Microwatts = "Microwatt",
     /** */
-    Milliwatts,
+    Milliwatts = "Milliwatt",
     /** */
-    Deciwatts,
+    Deciwatts = "Deciwatt",
     /** */
-    Decawatts,
+    Decawatts = "Decawatt",
     /** */
-    Kilowatts,
+    Kilowatts = "Kilowatt",
     /** */
-    Megawatts,
+    Megawatts = "Megawatt",
     /** */
-    Gigawatts,
+    Gigawatts = "Gigawatt",
     /** */
-    Terawatts,
+    Terawatts = "Terawatt",
     /** */
-    Petawatts
+    Petawatts = "Petawatt"
 }
 
 /** Luminosity is an absolute measure of radiated electromagnetic power (light), the radiant power emitted by a light-emitting object. */

--- a/src/luminousflux.g.ts
+++ b/src/luminousflux.g.ts
@@ -1,7 +1,7 @@
 /** LuminousFluxUnits enumeration */
 export enum LuminousFluxUnits {
     /** */
-    Lumens
+    Lumens = "Lumen"
 }
 
 /** In photometry, luminous flux or luminous power is the measure of the perceived power of light. */

--- a/src/luminousintensity.g.ts
+++ b/src/luminousintensity.g.ts
@@ -1,7 +1,7 @@
 /** LuminousIntensityUnits enumeration */
 export enum LuminousIntensityUnits {
     /** */
-    Candela
+    Candela = "Candela"
 }
 
 /** In photometry, luminous intensity is a measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle, based on the luminosity function, a standardized model of the sensitivity of the human eye. */

--- a/src/magneticfield.g.ts
+++ b/src/magneticfield.g.ts
@@ -1,17 +1,17 @@
 /** MagneticFieldUnits enumeration */
 export enum MagneticFieldUnits {
     /** */
-    Teslas,
+    Teslas = "Tesla",
     /** */
-    Gausses,
+    Gausses = "Gauss",
     /** */
-    Nanoteslas,
+    Nanoteslas = "Nanotesla",
     /** */
-    Microteslas,
+    Microteslas = "Microtesla",
     /** */
-    Milliteslas,
+    Milliteslas = "Millitesla",
     /** */
-    Milligausses
+    Milligausses = "Milligauss"
 }
 
 /** A magnetic field is a force field that is created by moving electric charges (electric currents) and magnetic dipoles, and exerts a force on other nearby moving charges and magnetic dipoles. */

--- a/src/magneticflux.g.ts
+++ b/src/magneticflux.g.ts
@@ -1,7 +1,7 @@
 /** MagneticFluxUnits enumeration */
 export enum MagneticFluxUnits {
     /** */
-    Webers
+    Webers = "Weber"
 }
 
 /** In physics, specifically electromagnetism, the magnetic flux through a surface is the surface integral of the normal component of the magnetic field B passing through that surface. */

--- a/src/magnetization.g.ts
+++ b/src/magnetization.g.ts
@@ -1,7 +1,7 @@
 /** MagnetizationUnits enumeration */
 export enum MagnetizationUnits {
     /** */
-    AmperesPerMeter
+    AmperesPerMeter = "AmperePerMeter"
 }
 
 /** In classical electromagnetism, magnetization is the vector field that expresses the density of permanent or induced magnetic dipole moments in a magnetic material. */

--- a/src/mass.g.ts
+++ b/src/mass.g.ts
@@ -1,59 +1,59 @@
 /** MassUnits enumeration */
 export enum MassUnits {
     /** */
-    Grams,
+    Grams = "Gram",
     /** */
-    Tonnes,
+    Tonnes = "Tonne",
     /** The short ton is a unit of mass equal to 2,000 pounds (907.18474 kg), that is most commonly used in the United States – known there simply as the ton. */
-    ShortTons,
+    ShortTons = "ShortTon",
     /** Long ton (weight ton or Imperial ton) is a unit of mass equal to 2,240 pounds (1,016 kg) and is the name for the unit called the "ton" in the avoirdupois or Imperial system of measurements that was used in the United Kingdom and several other Commonwealth countries before metrication. */
-    LongTons,
+    LongTons = "LongTon",
     /** The pound or pound-mass (abbreviations: lb, lbm) is a unit of mass used in the imperial, United States customary and other systems of measurement. A number of different definitions have been used, the most common today being the international avoirdupois pound which is legally defined as exactly 0.45359237 kilograms, and which is divided into 16 avoirdupois ounces. */
-    Pounds,
+    Pounds = "Pound",
     /** The international avoirdupois ounce (abbreviated oz) is defined as exactly 28.349523125 g under the international yard and pound agreement of 1959, signed by the United States and countries of the Commonwealth of Nations. 16 oz make up an avoirdupois pound. */
-    Ounces,
+    Ounces = "Ounce",
     /** The slug (abbreviation slug) is a unit of mass that is accelerated by 1 ft/s² when a force of one pound (lbf) is exerted on it. */
-    Slugs,
+    Slugs = "Slug",
     /** The stone (abbreviation st) is a unit of mass equal to 14 pounds avoirdupois (about 6.35 kilograms) used in Great Britain and Ireland for measuring human body weight. */
-    Stone,
+    Stone = "Stone",
     /** The short hundredweight (abbreviation cwt) is a unit of mass equal to 100 pounds in US and Canada. In British English, the short hundredweight is referred to as the "cental". */
-    ShortHundredweight,
+    ShortHundredweight = "ShortHundredweight",
     /** The long or imperial hundredweight (abbreviation cwt) is a unit of mass equal to 112 pounds in US and Canada. */
-    LongHundredweight,
+    LongHundredweight = "LongHundredweight",
     /** A grain is a unit of measurement of mass, and in the troy weight, avoirdupois, and Apothecaries' system, equal to exactly 64.79891 milligrams. */
-    Grains,
+    Grains = "Grain",
     /** Solar mass is a ratio unit to the mass of the solar system star, the sun. */
-    SolarMasses,
+    SolarMasses = "SolarMass",
     /** Earth mass is a ratio unit to the mass of planet Earth. */
-    EarthMasses,
+    EarthMasses = "EarthMass",
     /** */
-    Femtograms,
+    Femtograms = "Femtogram",
     /** */
-    Picograms,
+    Picograms = "Picogram",
     /** */
-    Nanograms,
+    Nanograms = "Nanogram",
     /** */
-    Micrograms,
+    Micrograms = "Microgram",
     /** */
-    Milligrams,
+    Milligrams = "Milligram",
     /** */
-    Centigrams,
+    Centigrams = "Centigram",
     /** */
-    Decigrams,
+    Decigrams = "Decigram",
     /** */
-    Decagrams,
+    Decagrams = "Decagram",
     /** */
-    Hectograms,
+    Hectograms = "Hectogram",
     /** */
-    Kilograms,
+    Kilograms = "Kilogram",
     /** */
-    Kilotonnes,
+    Kilotonnes = "Kilotonne",
     /** */
-    Megatonnes,
+    Megatonnes = "Megatonne",
     /** */
-    Kilopounds,
+    Kilopounds = "Kilopound",
     /** */
-    Megapounds
+    Megapounds = "Megapound"
 }
 
 /** In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg). */

--- a/src/massconcentration.g.ts
+++ b/src/massconcentration.g.ts
@@ -1,103 +1,103 @@
 /** MassConcentrationUnits enumeration */
 export enum MassConcentrationUnits {
     /** */
-    GramsPerCubicMillimeter,
+    GramsPerCubicMillimeter = "GramPerCubicMillimeter",
     /** */
-    GramsPerCubicCentimeter,
+    GramsPerCubicCentimeter = "GramPerCubicCentimeter",
     /** */
-    GramsPerCubicMeter,
+    GramsPerCubicMeter = "GramPerCubicMeter",
     /** */
-    GramsPerMicroliter,
+    GramsPerMicroliter = "GramPerMicroliter",
     /** */
-    GramsPerMilliliter,
+    GramsPerMilliliter = "GramPerMilliliter",
     /** */
-    GramsPerDeciliter,
+    GramsPerDeciliter = "GramPerDeciliter",
     /** */
-    GramsPerLiter,
+    GramsPerLiter = "GramPerLiter",
     /** */
-    TonnesPerCubicMillimeter,
+    TonnesPerCubicMillimeter = "TonnePerCubicMillimeter",
     /** */
-    TonnesPerCubicCentimeter,
+    TonnesPerCubicCentimeter = "TonnePerCubicCentimeter",
     /** */
-    TonnesPerCubicMeter,
+    TonnesPerCubicMeter = "TonnePerCubicMeter",
     /** */
-    PoundsPerCubicInch,
+    PoundsPerCubicInch = "PoundPerCubicInch",
     /** */
-    PoundsPerCubicFoot,
+    PoundsPerCubicFoot = "PoundPerCubicFoot",
     /** */
-    SlugsPerCubicFoot,
+    SlugsPerCubicFoot = "SlugPerCubicFoot",
     /** */
-    PoundsPerUSGallon,
+    PoundsPerUSGallon = "PoundPerUSGallon",
     /** */
-    OuncesPerUSGallon,
+    OuncesPerUSGallon = "OuncePerUSGallon",
     /** */
-    OuncesPerImperialGallon,
+    OuncesPerImperialGallon = "OuncePerImperialGallon",
     /** */
-    PoundsPerImperialGallon,
+    PoundsPerImperialGallon = "PoundPerImperialGallon",
     /** */
-    KilogramsPerCubicMillimeter,
+    KilogramsPerCubicMillimeter = "KilogramPerCubicMillimeter",
     /** */
-    KilogramsPerCubicCentimeter,
+    KilogramsPerCubicCentimeter = "KilogramPerCubicCentimeter",
     /** */
-    KilogramsPerCubicMeter,
+    KilogramsPerCubicMeter = "KilogramPerCubicMeter",
     /** */
-    MilligramsPerCubicMeter,
+    MilligramsPerCubicMeter = "MilligramPerCubicMeter",
     /** */
-    MicrogramsPerCubicMeter,
+    MicrogramsPerCubicMeter = "MicrogramPerCubicMeter",
     /** */
-    PicogramsPerMicroliter,
+    PicogramsPerMicroliter = "PicogramPerMicroliter",
     /** */
-    NanogramsPerMicroliter,
+    NanogramsPerMicroliter = "NanogramPerMicroliter",
     /** */
-    MicrogramsPerMicroliter,
+    MicrogramsPerMicroliter = "MicrogramPerMicroliter",
     /** */
-    MilligramsPerMicroliter,
+    MilligramsPerMicroliter = "MilligramPerMicroliter",
     /** */
-    CentigramsPerMicroliter,
+    CentigramsPerMicroliter = "CentigramPerMicroliter",
     /** */
-    DecigramsPerMicroliter,
+    DecigramsPerMicroliter = "DecigramPerMicroliter",
     /** */
-    PicogramsPerMilliliter,
+    PicogramsPerMilliliter = "PicogramPerMilliliter",
     /** */
-    NanogramsPerMilliliter,
+    NanogramsPerMilliliter = "NanogramPerMilliliter",
     /** */
-    MicrogramsPerMilliliter,
+    MicrogramsPerMilliliter = "MicrogramPerMilliliter",
     /** */
-    MilligramsPerMilliliter,
+    MilligramsPerMilliliter = "MilligramPerMilliliter",
     /** */
-    CentigramsPerMilliliter,
+    CentigramsPerMilliliter = "CentigramPerMilliliter",
     /** */
-    DecigramsPerMilliliter,
+    DecigramsPerMilliliter = "DecigramPerMilliliter",
     /** */
-    PicogramsPerDeciliter,
+    PicogramsPerDeciliter = "PicogramPerDeciliter",
     /** */
-    NanogramsPerDeciliter,
+    NanogramsPerDeciliter = "NanogramPerDeciliter",
     /** */
-    MicrogramsPerDeciliter,
+    MicrogramsPerDeciliter = "MicrogramPerDeciliter",
     /** */
-    MilligramsPerDeciliter,
+    MilligramsPerDeciliter = "MilligramPerDeciliter",
     /** */
-    CentigramsPerDeciliter,
+    CentigramsPerDeciliter = "CentigramPerDeciliter",
     /** */
-    DecigramsPerDeciliter,
+    DecigramsPerDeciliter = "DecigramPerDeciliter",
     /** */
-    PicogramsPerLiter,
+    PicogramsPerLiter = "PicogramPerLiter",
     /** */
-    NanogramsPerLiter,
+    NanogramsPerLiter = "NanogramPerLiter",
     /** */
-    MicrogramsPerLiter,
+    MicrogramsPerLiter = "MicrogramPerLiter",
     /** */
-    MilligramsPerLiter,
+    MilligramsPerLiter = "MilligramPerLiter",
     /** */
-    CentigramsPerLiter,
+    CentigramsPerLiter = "CentigramPerLiter",
     /** */
-    DecigramsPerLiter,
+    DecigramsPerLiter = "DecigramPerLiter",
     /** */
-    KilogramsPerLiter,
+    KilogramsPerLiter = "KilogramPerLiter",
     /** */
-    KilopoundsPerCubicInch,
+    KilopoundsPerCubicInch = "KilopoundPerCubicInch",
     /** */
-    KilopoundsPerCubicFoot
+    KilopoundsPerCubicFoot = "KilopoundPerCubicFoot"
 }
 
 /** In chemistry, the mass concentration ρi (or γi) is defined as the mass of a constituent mi divided by the volume of the mixture V */

--- a/src/massflow.g.ts
+++ b/src/massflow.g.ts
@@ -1,71 +1,71 @@
 /** MassFlowUnits enumeration */
 export enum MassFlowUnits {
     /** */
-    GramsPerSecond,
+    GramsPerSecond = "GramPerSecond",
     /** */
-    GramsPerDay,
+    GramsPerDay = "GramPerDay",
     /** */
-    GramsPerHour,
+    GramsPerHour = "GramPerHour",
     /** */
-    KilogramsPerHour,
+    KilogramsPerHour = "KilogramPerHour",
     /** */
-    KilogramsPerMinute,
+    KilogramsPerMinute = "KilogramPerMinute",
     /** */
-    TonnesPerHour,
+    TonnesPerHour = "TonnePerHour",
     /** */
-    PoundsPerDay,
+    PoundsPerDay = "PoundPerDay",
     /** */
-    PoundsPerHour,
+    PoundsPerHour = "PoundPerHour",
     /** */
-    PoundsPerMinute,
+    PoundsPerMinute = "PoundPerMinute",
     /** */
-    PoundsPerSecond,
+    PoundsPerSecond = "PoundPerSecond",
     /** */
-    TonnesPerDay,
+    TonnesPerDay = "TonnePerDay",
     /** */
-    ShortTonsPerHour,
+    ShortTonsPerHour = "ShortTonPerHour",
     /** */
-    NanogramsPerSecond,
+    NanogramsPerSecond = "NanogramPerSecond",
     /** */
-    MicrogramsPerSecond,
+    MicrogramsPerSecond = "MicrogramPerSecond",
     /** */
-    MilligramsPerSecond,
+    MilligramsPerSecond = "MilligramPerSecond",
     /** */
-    CentigramsPerSecond,
+    CentigramsPerSecond = "CentigramPerSecond",
     /** */
-    DecigramsPerSecond,
+    DecigramsPerSecond = "DecigramPerSecond",
     /** */
-    DecagramsPerSecond,
+    DecagramsPerSecond = "DecagramPerSecond",
     /** */
-    HectogramsPerSecond,
+    HectogramsPerSecond = "HectogramPerSecond",
     /** */
-    KilogramsPerSecond,
+    KilogramsPerSecond = "KilogramPerSecond",
     /** */
-    NanogramsPerDay,
+    NanogramsPerDay = "NanogramPerDay",
     /** */
-    MicrogramsPerDay,
+    MicrogramsPerDay = "MicrogramPerDay",
     /** */
-    MilligramsPerDay,
+    MilligramsPerDay = "MilligramPerDay",
     /** */
-    CentigramsPerDay,
+    CentigramsPerDay = "CentigramPerDay",
     /** */
-    DecigramsPerDay,
+    DecigramsPerDay = "DecigramPerDay",
     /** */
-    DecagramsPerDay,
+    DecagramsPerDay = "DecagramPerDay",
     /** */
-    HectogramsPerDay,
+    HectogramsPerDay = "HectogramPerDay",
     /** */
-    KilogramsPerDay,
+    KilogramsPerDay = "KilogramPerDay",
     /** */
-    MegagramsPerDay,
+    MegagramsPerDay = "MegagramPerDay",
     /** */
-    MegapoundsPerDay,
+    MegapoundsPerDay = "MegapoundPerDay",
     /** */
-    MegapoundsPerHour,
+    MegapoundsPerHour = "MegapoundPerHour",
     /** */
-    MegapoundsPerMinute,
+    MegapoundsPerMinute = "MegapoundPerMinute",
     /** */
-    MegapoundsPerSecond
+    MegapoundsPerSecond = "MegapoundPerSecond"
 }
 
 /** Mass flow is the ratio of the mass change to the time during which the change occurred (value of mass changes per unit time). */

--- a/src/massflux.g.ts
+++ b/src/massflux.g.ts
@@ -1,29 +1,29 @@
 /** MassFluxUnits enumeration */
 export enum MassFluxUnits {
     /** */
-    GramsPerSecondPerSquareMeter,
+    GramsPerSecondPerSquareMeter = "GramPerSecondPerSquareMeter",
     /** */
-    GramsPerSecondPerSquareCentimeter,
+    GramsPerSecondPerSquareCentimeter = "GramPerSecondPerSquareCentimeter",
     /** */
-    GramsPerSecondPerSquareMillimeter,
+    GramsPerSecondPerSquareMillimeter = "GramPerSecondPerSquareMillimeter",
     /** */
-    GramsPerHourPerSquareMeter,
+    GramsPerHourPerSquareMeter = "GramPerHourPerSquareMeter",
     /** */
-    GramsPerHourPerSquareCentimeter,
+    GramsPerHourPerSquareCentimeter = "GramPerHourPerSquareCentimeter",
     /** */
-    GramsPerHourPerSquareMillimeter,
+    GramsPerHourPerSquareMillimeter = "GramPerHourPerSquareMillimeter",
     /** */
-    KilogramsPerSecondPerSquareMeter,
+    KilogramsPerSecondPerSquareMeter = "KilogramPerSecondPerSquareMeter",
     /** */
-    KilogramsPerSecondPerSquareCentimeter,
+    KilogramsPerSecondPerSquareCentimeter = "KilogramPerSecondPerSquareCentimeter",
     /** */
-    KilogramsPerSecondPerSquareMillimeter,
+    KilogramsPerSecondPerSquareMillimeter = "KilogramPerSecondPerSquareMillimeter",
     /** */
-    KilogramsPerHourPerSquareMeter,
+    KilogramsPerHourPerSquareMeter = "KilogramPerHourPerSquareMeter",
     /** */
-    KilogramsPerHourPerSquareCentimeter,
+    KilogramsPerHourPerSquareCentimeter = "KilogramPerHourPerSquareCentimeter",
     /** */
-    KilogramsPerHourPerSquareMillimeter
+    KilogramsPerHourPerSquareMillimeter = "KilogramPerHourPerSquareMillimeter"
 }
 
 /** Mass flux is the mass flow rate per unit area. */

--- a/src/massfraction.g.ts
+++ b/src/massfraction.g.ts
@@ -1,53 +1,53 @@
 /** MassFractionUnits enumeration */
 export enum MassFractionUnits {
     /** */
-    DecimalFractions,
+    DecimalFractions = "DecimalFraction",
     /** */
-    GramsPerGram,
+    GramsPerGram = "GramPerGram",
     /** */
-    GramsPerKilogram,
+    GramsPerKilogram = "GramPerKilogram",
     /** */
-    Percent,
+    Percent = "Percent",
     /** */
-    PartsPerThousand,
+    PartsPerThousand = "PartPerThousand",
     /** */
-    PartsPerMillion,
+    PartsPerMillion = "PartPerMillion",
     /** */
-    PartsPerBillion,
+    PartsPerBillion = "PartPerBillion",
     /** */
-    PartsPerTrillion,
+    PartsPerTrillion = "PartPerTrillion",
     /** */
-    NanogramsPerGram,
+    NanogramsPerGram = "NanogramPerGram",
     /** */
-    MicrogramsPerGram,
+    MicrogramsPerGram = "MicrogramPerGram",
     /** */
-    MilligramsPerGram,
+    MilligramsPerGram = "MilligramPerGram",
     /** */
-    CentigramsPerGram,
+    CentigramsPerGram = "CentigramPerGram",
     /** */
-    DecigramsPerGram,
+    DecigramsPerGram = "DecigramPerGram",
     /** */
-    DecagramsPerGram,
+    DecagramsPerGram = "DecagramPerGram",
     /** */
-    HectogramsPerGram,
+    HectogramsPerGram = "HectogramPerGram",
     /** */
-    KilogramsPerGram,
+    KilogramsPerGram = "KilogramPerGram",
     /** */
-    NanogramsPerKilogram,
+    NanogramsPerKilogram = "NanogramPerKilogram",
     /** */
-    MicrogramsPerKilogram,
+    MicrogramsPerKilogram = "MicrogramPerKilogram",
     /** */
-    MilligramsPerKilogram,
+    MilligramsPerKilogram = "MilligramPerKilogram",
     /** */
-    CentigramsPerKilogram,
+    CentigramsPerKilogram = "CentigramPerKilogram",
     /** */
-    DecigramsPerKilogram,
+    DecigramsPerKilogram = "DecigramPerKilogram",
     /** */
-    DecagramsPerKilogram,
+    DecagramsPerKilogram = "DecagramPerKilogram",
     /** */
-    HectogramsPerKilogram,
+    HectogramsPerKilogram = "HectogramPerKilogram",
     /** */
-    KilogramsPerKilogram
+    KilogramsPerKilogram = "KilogramPerKilogram"
 }
 
 /** The mass fraction is defined as the mass of a constituent divided by the total mass of the mixture. */

--- a/src/massmomentofinertia.g.ts
+++ b/src/massmomentofinertia.g.ts
@@ -1,61 +1,61 @@
 /** MassMomentOfInertiaUnits enumeration */
 export enum MassMomentOfInertiaUnits {
     /** */
-    GramSquareMeters,
+    GramSquareMeters = "GramSquareMeter",
     /** */
-    GramSquareDecimeters,
+    GramSquareDecimeters = "GramSquareDecimeter",
     /** */
-    GramSquareCentimeters,
+    GramSquareCentimeters = "GramSquareCentimeter",
     /** */
-    GramSquareMillimeters,
+    GramSquareMillimeters = "GramSquareMillimeter",
     /** */
-    TonneSquareMeters,
+    TonneSquareMeters = "TonneSquareMeter",
     /** */
-    TonneSquareDecimeters,
+    TonneSquareDecimeters = "TonneSquareDecimeter",
     /** */
-    TonneSquareCentimeters,
+    TonneSquareCentimeters = "TonneSquareCentimeter",
     /** */
-    TonneSquareMilimeters,
+    TonneSquareMilimeters = "TonneSquareMilimeter",
     /** */
-    PoundSquareFeet,
+    PoundSquareFeet = "PoundSquareFoot",
     /** */
-    PoundSquareInches,
+    PoundSquareInches = "PoundSquareInch",
     /** */
-    SlugSquareFeet,
+    SlugSquareFeet = "SlugSquareFoot",
     /** */
-    SlugSquareInches,
+    SlugSquareInches = "SlugSquareInch",
     /** */
-    MilligramSquareMeters,
+    MilligramSquareMeters = "MilligramSquareMeter",
     /** */
-    KilogramSquareMeters,
+    KilogramSquareMeters = "KilogramSquareMeter",
     /** */
-    MilligramSquareDecimeters,
+    MilligramSquareDecimeters = "MilligramSquareDecimeter",
     /** */
-    KilogramSquareDecimeters,
+    KilogramSquareDecimeters = "KilogramSquareDecimeter",
     /** */
-    MilligramSquareCentimeters,
+    MilligramSquareCentimeters = "MilligramSquareCentimeter",
     /** */
-    KilogramSquareCentimeters,
+    KilogramSquareCentimeters = "KilogramSquareCentimeter",
     /** */
-    MilligramSquareMillimeters,
+    MilligramSquareMillimeters = "MilligramSquareMillimeter",
     /** */
-    KilogramSquareMillimeters,
+    KilogramSquareMillimeters = "KilogramSquareMillimeter",
     /** */
-    KilotonneSquareMeters,
+    KilotonneSquareMeters = "KilotonneSquareMeter",
     /** */
-    MegatonneSquareMeters,
+    MegatonneSquareMeters = "MegatonneSquareMeter",
     /** */
-    KilotonneSquareDecimeters,
+    KilotonneSquareDecimeters = "KilotonneSquareDecimeter",
     /** */
-    MegatonneSquareDecimeters,
+    MegatonneSquareDecimeters = "MegatonneSquareDecimeter",
     /** */
-    KilotonneSquareCentimeters,
+    KilotonneSquareCentimeters = "KilotonneSquareCentimeter",
     /** */
-    MegatonneSquareCentimeters,
+    MegatonneSquareCentimeters = "MegatonneSquareCentimeter",
     /** */
-    KilotonneSquareMilimeters,
+    KilotonneSquareMilimeters = "KilotonneSquareMilimeter",
     /** */
-    MegatonneSquareMilimeters
+    MegatonneSquareMilimeters = "MegatonneSquareMilimeter"
 }
 
 /** A property of body reflects how its mass is distributed with regard to an axis. */

--- a/src/molality.g.ts
+++ b/src/molality.g.ts
@@ -1,9 +1,9 @@
 /** MolalityUnits enumeration */
 export enum MolalityUnits {
     /** */
-    MolesPerKilogram,
+    MolesPerKilogram = "MolePerKilogram",
     /** */
-    MolesPerGram
+    MolesPerGram = "MolePerGram"
 }
 
 /** Molality is a measure of the amount of solute in a solution relative to a given mass of solvent. */

--- a/src/molarenergy.g.ts
+++ b/src/molarenergy.g.ts
@@ -1,11 +1,11 @@
 /** MolarEnergyUnits enumeration */
 export enum MolarEnergyUnits {
     /** */
-    JoulesPerMole,
+    JoulesPerMole = "JoulePerMole",
     /** */
-    KilojoulesPerMole,
+    KilojoulesPerMole = "KilojoulePerMole",
     /** */
-    MegajoulesPerMole
+    MegajoulesPerMole = "MegajoulePerMole"
 }
 
 /** Molar energy is the amount of energy stored in 1 mole of a substance. */

--- a/src/molarentropy.g.ts
+++ b/src/molarentropy.g.ts
@@ -1,11 +1,11 @@
 /** MolarEntropyUnits enumeration */
 export enum MolarEntropyUnits {
     /** */
-    JoulesPerMoleKelvin,
+    JoulesPerMoleKelvin = "JoulePerMoleKelvin",
     /** */
-    KilojoulesPerMoleKelvin,
+    KilojoulesPerMoleKelvin = "KilojoulePerMoleKelvin",
     /** */
-    MegajoulesPerMoleKelvin
+    MegajoulesPerMoleKelvin = "MegajoulePerMoleKelvin"
 }
 
 /** Molar entropy is amount of energy required to increase temperature of 1 mole substance by 1 Kelvin. */

--- a/src/molarflow.g.ts
+++ b/src/molarflow.g.ts
@@ -1,23 +1,23 @@
 /** MolarFlowUnits enumeration */
 export enum MolarFlowUnits {
     /** */
-    MolesPerSecond,
+    MolesPerSecond = "MolePerSecond",
     /** */
-    MolesPerMinute,
+    MolesPerMinute = "MolePerMinute",
     /** */
-    MolesPerHour,
+    MolesPerHour = "MolePerHour",
     /** */
-    PoundMolesPerSecond,
+    PoundMolesPerSecond = "PoundMolePerSecond",
     /** */
-    PoundMolesPerMinute,
+    PoundMolesPerMinute = "PoundMolePerMinute",
     /** */
-    PoundMolesPerHour,
+    PoundMolesPerHour = "PoundMolePerHour",
     /** */
-    KilomolesPerSecond,
+    KilomolesPerSecond = "KilomolePerSecond",
     /** */
-    KilomolesPerMinute,
+    KilomolesPerMinute = "KilomolePerMinute",
     /** */
-    KilomolesPerHour
+    KilomolesPerHour = "KilomolePerHour"
 }
 
 /** Molar flow is the ratio of the amount of substance change to the time during which the change occurred (value of amount of substance changes per unit time). */

--- a/src/molarity.g.ts
+++ b/src/molarity.g.ts
@@ -1,27 +1,27 @@
 /** MolarityUnits enumeration */
 export enum MolarityUnits {
     /** */
-    MolesPerCubicMeter,
+    MolesPerCubicMeter = "MolePerCubicMeter",
     /** */
-    MolesPerLiter,
+    MolesPerLiter = "MolePerLiter",
     /** */
-    PoundMolesPerCubicFoot,
+    PoundMolesPerCubicFoot = "PoundMolePerCubicFoot",
     /** */
-    KilomolesPerCubicMeter,
+    KilomolesPerCubicMeter = "KilomolePerCubicMeter",
     /** */
-    FemtomolesPerLiter,
+    FemtomolesPerLiter = "FemtomolePerLiter",
     /** */
-    PicomolesPerLiter,
+    PicomolesPerLiter = "PicomolePerLiter",
     /** */
-    NanomolesPerLiter,
+    NanomolesPerLiter = "NanomolePerLiter",
     /** */
-    MicromolesPerLiter,
+    MicromolesPerLiter = "MicromolePerLiter",
     /** */
-    MillimolesPerLiter,
+    MillimolesPerLiter = "MillimolePerLiter",
     /** */
-    CentimolesPerLiter,
+    CentimolesPerLiter = "CentimolePerLiter",
     /** */
-    DecimolesPerLiter
+    DecimolesPerLiter = "DecimolePerLiter"
 }
 
 /** Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume. */

--- a/src/molarmass.g.ts
+++ b/src/molarmass.g.ts
@@ -1,31 +1,31 @@
 /** MolarMassUnits enumeration */
 export enum MolarMassUnits {
     /** */
-    GramsPerMole,
+    GramsPerMole = "GramPerMole",
     /** */
-    KilogramsPerKilomole,
+    KilogramsPerKilomole = "KilogramPerKilomole",
     /** */
-    PoundsPerMole,
+    PoundsPerMole = "PoundPerMole",
     /** */
-    NanogramsPerMole,
+    NanogramsPerMole = "NanogramPerMole",
     /** */
-    MicrogramsPerMole,
+    MicrogramsPerMole = "MicrogramPerMole",
     /** */
-    MilligramsPerMole,
+    MilligramsPerMole = "MilligramPerMole",
     /** */
-    CentigramsPerMole,
+    CentigramsPerMole = "CentigramPerMole",
     /** */
-    DecigramsPerMole,
+    DecigramsPerMole = "DecigramPerMole",
     /** */
-    DecagramsPerMole,
+    DecagramsPerMole = "DecagramPerMole",
     /** */
-    HectogramsPerMole,
+    HectogramsPerMole = "HectogramPerMole",
     /** */
-    KilogramsPerMole,
+    KilogramsPerMole = "KilogramPerMole",
     /** */
-    KilopoundsPerMole,
+    KilopoundsPerMole = "KilopoundPerMole",
     /** */
-    MegapoundsPerMole
+    MegapoundsPerMole = "MegapoundPerMole"
 }
 
 /** In chemistry, the molar mass M is a physical property defined as the mass of a given substance (chemical element or chemical compound) divided by the amount of substance. */

--- a/src/permeability.g.ts
+++ b/src/permeability.g.ts
@@ -1,7 +1,7 @@
 /** PermeabilityUnits enumeration */
 export enum PermeabilityUnits {
     /** */
-    HenriesPerMeter
+    HenriesPerMeter = "HenryPerMeter"
 }
 
 /** In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself. */

--- a/src/permittivity.g.ts
+++ b/src/permittivity.g.ts
@@ -1,7 +1,7 @@
 /** PermittivityUnits enumeration */
 export enum PermittivityUnits {
     /** */
-    FaradsPerMeter
+    FaradsPerMeter = "FaradPerMeter"
 }
 
 /** In electromagnetism, permittivity is the measure of resistance that is encountered when forming an electric field in a particular medium. */

--- a/src/porousmediumpermeability.g.ts
+++ b/src/porousmediumpermeability.g.ts
@@ -1,15 +1,15 @@
 /** PorousMediumPermeabilityUnits enumeration */
 export enum PorousMediumPermeabilityUnits {
     /** */
-    Darcys,
+    Darcys = "Darcy",
     /** */
-    SquareMeters,
+    SquareMeters = "SquareMeter",
     /** */
-    SquareCentimeters,
+    SquareCentimeters = "SquareCentimeter",
     /** */
-    Microdarcys,
+    Microdarcys = "Microdarcy",
     /** */
-    Millidarcys
+    Millidarcys = "Millidarcy"
 }
 
 /** In fluid mechanics, permeability is the measure of the ability of a porous material to allow fluids to pass through it. */

--- a/src/power.g.ts
+++ b/src/power.g.ts
@@ -1,57 +1,57 @@
 /** PowerUnits enumeration */
 export enum PowerUnits {
     /** */
-    Watts,
+    Watts = "Watt",
     /** */
-    MechanicalHorsepower,
+    MechanicalHorsepower = "MechanicalHorsepower",
     /** */
-    MetricHorsepower,
+    MetricHorsepower = "MetricHorsepower",
     /** */
-    ElectricalHorsepower,
+    ElectricalHorsepower = "ElectricalHorsepower",
     /** */
-    BoilerHorsepower,
+    BoilerHorsepower = "BoilerHorsepower",
     /** */
-    HydraulicHorsepower,
+    HydraulicHorsepower = "HydraulicHorsepower",
     /** */
-    BritishThermalUnitsPerHour,
+    BritishThermalUnitsPerHour = "BritishThermalUnitPerHour",
     /** */
-    JoulesPerHour,
+    JoulesPerHour = "JoulePerHour",
     /** */
-    Femtowatts,
+    Femtowatts = "Femtowatt",
     /** */
-    Picowatts,
+    Picowatts = "Picowatt",
     /** */
-    Nanowatts,
+    Nanowatts = "Nanowatt",
     /** */
-    Microwatts,
+    Microwatts = "Microwatt",
     /** */
-    Milliwatts,
+    Milliwatts = "Milliwatt",
     /** */
-    Deciwatts,
+    Deciwatts = "Deciwatt",
     /** */
-    Decawatts,
+    Decawatts = "Decawatt",
     /** */
-    Kilowatts,
+    Kilowatts = "Kilowatt",
     /** */
-    Megawatts,
+    Megawatts = "Megawatt",
     /** */
-    Gigawatts,
+    Gigawatts = "Gigawatt",
     /** */
-    Terawatts,
+    Terawatts = "Terawatt",
     /** */
-    Petawatts,
+    Petawatts = "Petawatt",
     /** */
-    KilobritishThermalUnitsPerHour,
+    KilobritishThermalUnitsPerHour = "KilobritishThermalUnitPerHour",
     /** */
-    MegabritishThermalUnitsPerHour,
+    MegabritishThermalUnitsPerHour = "MegabritishThermalUnitPerHour",
     /** */
-    MillijoulesPerHour,
+    MillijoulesPerHour = "MillijoulePerHour",
     /** */
-    KilojoulesPerHour,
+    KilojoulesPerHour = "KilojoulePerHour",
     /** */
-    MegajoulesPerHour,
+    MegajoulesPerHour = "MegajoulePerHour",
     /** */
-    GigajoulesPerHour
+    GigajoulesPerHour = "GigajoulePerHour"
 }
 
 /** In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time. */

--- a/src/powerdensity.g.ts
+++ b/src/powerdensity.g.ts
@@ -1,93 +1,93 @@
 /** PowerDensityUnits enumeration */
 export enum PowerDensityUnits {
     /** */
-    WattsPerCubicMeter,
+    WattsPerCubicMeter = "WattPerCubicMeter",
     /** */
-    WattsPerCubicInch,
+    WattsPerCubicInch = "WattPerCubicInch",
     /** */
-    WattsPerCubicFoot,
+    WattsPerCubicFoot = "WattPerCubicFoot",
     /** */
-    WattsPerLiter,
+    WattsPerLiter = "WattPerLiter",
     /** */
-    PicowattsPerCubicMeter,
+    PicowattsPerCubicMeter = "PicowattPerCubicMeter",
     /** */
-    NanowattsPerCubicMeter,
+    NanowattsPerCubicMeter = "NanowattPerCubicMeter",
     /** */
-    MicrowattsPerCubicMeter,
+    MicrowattsPerCubicMeter = "MicrowattPerCubicMeter",
     /** */
-    MilliwattsPerCubicMeter,
+    MilliwattsPerCubicMeter = "MilliwattPerCubicMeter",
     /** */
-    DeciwattsPerCubicMeter,
+    DeciwattsPerCubicMeter = "DeciwattPerCubicMeter",
     /** */
-    DecawattsPerCubicMeter,
+    DecawattsPerCubicMeter = "DecawattPerCubicMeter",
     /** */
-    KilowattsPerCubicMeter,
+    KilowattsPerCubicMeter = "KilowattPerCubicMeter",
     /** */
-    MegawattsPerCubicMeter,
+    MegawattsPerCubicMeter = "MegawattPerCubicMeter",
     /** */
-    GigawattsPerCubicMeter,
+    GigawattsPerCubicMeter = "GigawattPerCubicMeter",
     /** */
-    TerawattsPerCubicMeter,
+    TerawattsPerCubicMeter = "TerawattPerCubicMeter",
     /** */
-    PicowattsPerCubicInch,
+    PicowattsPerCubicInch = "PicowattPerCubicInch",
     /** */
-    NanowattsPerCubicInch,
+    NanowattsPerCubicInch = "NanowattPerCubicInch",
     /** */
-    MicrowattsPerCubicInch,
+    MicrowattsPerCubicInch = "MicrowattPerCubicInch",
     /** */
-    MilliwattsPerCubicInch,
+    MilliwattsPerCubicInch = "MilliwattPerCubicInch",
     /** */
-    DeciwattsPerCubicInch,
+    DeciwattsPerCubicInch = "DeciwattPerCubicInch",
     /** */
-    DecawattsPerCubicInch,
+    DecawattsPerCubicInch = "DecawattPerCubicInch",
     /** */
-    KilowattsPerCubicInch,
+    KilowattsPerCubicInch = "KilowattPerCubicInch",
     /** */
-    MegawattsPerCubicInch,
+    MegawattsPerCubicInch = "MegawattPerCubicInch",
     /** */
-    GigawattsPerCubicInch,
+    GigawattsPerCubicInch = "GigawattPerCubicInch",
     /** */
-    TerawattsPerCubicInch,
+    TerawattsPerCubicInch = "TerawattPerCubicInch",
     /** */
-    PicowattsPerCubicFoot,
+    PicowattsPerCubicFoot = "PicowattPerCubicFoot",
     /** */
-    NanowattsPerCubicFoot,
+    NanowattsPerCubicFoot = "NanowattPerCubicFoot",
     /** */
-    MicrowattsPerCubicFoot,
+    MicrowattsPerCubicFoot = "MicrowattPerCubicFoot",
     /** */
-    MilliwattsPerCubicFoot,
+    MilliwattsPerCubicFoot = "MilliwattPerCubicFoot",
     /** */
-    DeciwattsPerCubicFoot,
+    DeciwattsPerCubicFoot = "DeciwattPerCubicFoot",
     /** */
-    DecawattsPerCubicFoot,
+    DecawattsPerCubicFoot = "DecawattPerCubicFoot",
     /** */
-    KilowattsPerCubicFoot,
+    KilowattsPerCubicFoot = "KilowattPerCubicFoot",
     /** */
-    MegawattsPerCubicFoot,
+    MegawattsPerCubicFoot = "MegawattPerCubicFoot",
     /** */
-    GigawattsPerCubicFoot,
+    GigawattsPerCubicFoot = "GigawattPerCubicFoot",
     /** */
-    TerawattsPerCubicFoot,
+    TerawattsPerCubicFoot = "TerawattPerCubicFoot",
     /** */
-    PicowattsPerLiter,
+    PicowattsPerLiter = "PicowattPerLiter",
     /** */
-    NanowattsPerLiter,
+    NanowattsPerLiter = "NanowattPerLiter",
     /** */
-    MicrowattsPerLiter,
+    MicrowattsPerLiter = "MicrowattPerLiter",
     /** */
-    MilliwattsPerLiter,
+    MilliwattsPerLiter = "MilliwattPerLiter",
     /** */
-    DeciwattsPerLiter,
+    DeciwattsPerLiter = "DeciwattPerLiter",
     /** */
-    DecawattsPerLiter,
+    DecawattsPerLiter = "DecawattPerLiter",
     /** */
-    KilowattsPerLiter,
+    KilowattsPerLiter = "KilowattPerLiter",
     /** */
-    MegawattsPerLiter,
+    MegawattsPerLiter = "MegawattPerLiter",
     /** */
-    GigawattsPerLiter,
+    GigawattsPerLiter = "GigawattPerLiter",
     /** */
-    TerawattsPerLiter
+    TerawattsPerLiter = "TerawattPerLiter"
 }
 
 /** The amount of power in a volume. */

--- a/src/powerratio.g.ts
+++ b/src/powerratio.g.ts
@@ -1,9 +1,9 @@
 /** PowerRatioUnits enumeration */
 export enum PowerRatioUnits {
     /** */
-    DecibelWatts,
+    DecibelWatts = "DecibelWatt",
     /** */
-    DecibelMilliwatts
+    DecibelMilliwatts = "DecibelMilliwatt"
 }
 
 /** The strength of a signal expressed in decibels (dB) relative to one watt. */

--- a/src/pressure.g.ts
+++ b/src/pressure.g.ts
@@ -1,103 +1,103 @@
 /** PressureUnits enumeration */
 export enum PressureUnits {
     /** */
-    Pascals,
+    Pascals = "Pascal",
     /** */
-    Atmospheres,
+    Atmospheres = "Atmosphere",
     /** */
-    Bars,
+    Bars = "Bar",
     /** */
-    KilogramsForcePerSquareMeter,
+    KilogramsForcePerSquareMeter = "KilogramForcePerSquareMeter",
     /** */
-    KilogramsForcePerSquareCentimeter,
+    KilogramsForcePerSquareCentimeter = "KilogramForcePerSquareCentimeter",
     /** */
-    KilogramsForcePerSquareMillimeter,
+    KilogramsForcePerSquareMillimeter = "KilogramForcePerSquareMillimeter",
     /** */
-    NewtonsPerSquareMeter,
+    NewtonsPerSquareMeter = "NewtonPerSquareMeter",
     /** */
-    NewtonsPerSquareCentimeter,
+    NewtonsPerSquareCentimeter = "NewtonPerSquareCentimeter",
     /** */
-    NewtonsPerSquareMillimeter,
+    NewtonsPerSquareMillimeter = "NewtonPerSquareMillimeter",
     /** */
-    TechnicalAtmospheres,
+    TechnicalAtmospheres = "TechnicalAtmosphere",
     /** */
-    Torrs,
+    Torrs = "Torr",
     /** */
-    PoundsForcePerSquareInch,
+    PoundsForcePerSquareInch = "PoundForcePerSquareInch",
     /** */
-    PoundsForcePerSquareMil,
+    PoundsForcePerSquareMil = "PoundForcePerSquareMil",
     /** */
-    PoundsForcePerSquareFoot,
+    PoundsForcePerSquareFoot = "PoundForcePerSquareFoot",
     /** */
-    TonnesForcePerSquareMillimeter,
+    TonnesForcePerSquareMillimeter = "TonneForcePerSquareMillimeter",
     /** */
-    TonnesForcePerSquareMeter,
+    TonnesForcePerSquareMeter = "TonneForcePerSquareMeter",
     /** */
-    MetersOfHead,
+    MetersOfHead = "MeterOfHead",
     /** */
-    TonnesForcePerSquareCentimeter,
+    TonnesForcePerSquareCentimeter = "TonneForcePerSquareCentimeter",
     /** */
-    FeetOfHead,
+    FeetOfHead = "FootOfHead",
     /** */
-    MillimetersOfMercury,
+    MillimetersOfMercury = "MillimeterOfMercury",
     /** */
-    InchesOfMercury,
+    InchesOfMercury = "InchOfMercury",
     /** */
-    DynesPerSquareCentimeter,
+    DynesPerSquareCentimeter = "DynePerSquareCentimeter",
     /** */
-    PoundsPerInchSecondSquared,
+    PoundsPerInchSecondSquared = "PoundPerInchSecondSquared",
     /** */
-    MetersOfWaterColumn,
+    MetersOfWaterColumn = "MeterOfWaterColumn",
     /** */
-    InchesOfWaterColumn,
+    InchesOfWaterColumn = "InchOfWaterColumn",
     /** */
-    MetersOfElevation,
+    MetersOfElevation = "MeterOfElevation",
     /** */
-    FeetOfElevation,
+    FeetOfElevation = "FootOfElevation",
     /** */
-    Micropascals,
+    Micropascals = "Micropascal",
     /** */
-    Millipascals,
+    Millipascals = "Millipascal",
     /** */
-    Decapascals,
+    Decapascals = "Decapascal",
     /** */
-    Hectopascals,
+    Hectopascals = "Hectopascal",
     /** */
-    Kilopascals,
+    Kilopascals = "Kilopascal",
     /** */
-    Megapascals,
+    Megapascals = "Megapascal",
     /** */
-    Gigapascals,
+    Gigapascals = "Gigapascal",
     /** */
-    Microbars,
+    Microbars = "Microbar",
     /** */
-    Millibars,
+    Millibars = "Millibar",
     /** */
-    Centibars,
+    Centibars = "Centibar",
     /** */
-    Decibars,
+    Decibars = "Decibar",
     /** */
-    Kilobars,
+    Kilobars = "Kilobar",
     /** */
-    Megabars,
+    Megabars = "Megabar",
     /** */
-    KilonewtonsPerSquareMeter,
+    KilonewtonsPerSquareMeter = "KilonewtonPerSquareMeter",
     /** */
-    MeganewtonsPerSquareMeter,
+    MeganewtonsPerSquareMeter = "MeganewtonPerSquareMeter",
     /** */
-    KilonewtonsPerSquareCentimeter,
+    KilonewtonsPerSquareCentimeter = "KilonewtonPerSquareCentimeter",
     /** */
-    KilonewtonsPerSquareMillimeter,
+    KilonewtonsPerSquareMillimeter = "KilonewtonPerSquareMillimeter",
     /** */
-    KilopoundsForcePerSquareInch,
+    KilopoundsForcePerSquareInch = "KilopoundForcePerSquareInch",
     /** */
-    KilopoundsForcePerSquareMil,
+    KilopoundsForcePerSquareMil = "KilopoundForcePerSquareMil",
     /** */
-    KilopoundsForcePerSquareFoot,
+    KilopoundsForcePerSquareFoot = "KilopoundForcePerSquareFoot",
     /** */
-    MillimetersOfWaterColumn,
+    MillimetersOfWaterColumn = "MillimeterOfWaterColumn",
     /** */
-    CentimetersOfWaterColumn
+    CentimetersOfWaterColumn = "CentimeterOfWaterColumn"
 }
 
 /** Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa). */

--- a/src/pressurechangerate.g.ts
+++ b/src/pressurechangerate.g.ts
@@ -1,41 +1,41 @@
 /** PressureChangeRateUnits enumeration */
 export enum PressureChangeRateUnits {
     /** */
-    PascalsPerSecond,
+    PascalsPerSecond = "PascalPerSecond",
     /** */
-    PascalsPerMinute,
+    PascalsPerMinute = "PascalPerMinute",
     /** */
-    MillimetersOfMercuryPerSecond,
+    MillimetersOfMercuryPerSecond = "MillimeterOfMercuryPerSecond",
     /** */
-    AtmospheresPerSecond,
+    AtmospheresPerSecond = "AtmospherePerSecond",
     /** */
-    PoundsForcePerSquareInchPerSecond,
+    PoundsForcePerSquareInchPerSecond = "PoundForcePerSquareInchPerSecond",
     /** */
-    PoundsForcePerSquareInchPerMinute,
+    PoundsForcePerSquareInchPerMinute = "PoundForcePerSquareInchPerMinute",
     /** */
-    BarsPerSecond,
+    BarsPerSecond = "BarPerSecond",
     /** */
-    BarsPerMinute,
+    BarsPerMinute = "BarPerMinute",
     /** */
-    KilopascalsPerSecond,
+    KilopascalsPerSecond = "KilopascalPerSecond",
     /** */
-    MegapascalsPerSecond,
+    MegapascalsPerSecond = "MegapascalPerSecond",
     /** */
-    KilopascalsPerMinute,
+    KilopascalsPerMinute = "KilopascalPerMinute",
     /** */
-    MegapascalsPerMinute,
+    MegapascalsPerMinute = "MegapascalPerMinute",
     /** */
-    KilopoundsForcePerSquareInchPerSecond,
+    KilopoundsForcePerSquareInchPerSecond = "KilopoundForcePerSquareInchPerSecond",
     /** */
-    MegapoundsForcePerSquareInchPerSecond,
+    MegapoundsForcePerSquareInchPerSecond = "MegapoundForcePerSquareInchPerSecond",
     /** */
-    KilopoundsForcePerSquareInchPerMinute,
+    KilopoundsForcePerSquareInchPerMinute = "KilopoundForcePerSquareInchPerMinute",
     /** */
-    MegapoundsForcePerSquareInchPerMinute,
+    MegapoundsForcePerSquareInchPerMinute = "MegapoundForcePerSquareInchPerMinute",
     /** */
-    MillibarsPerSecond,
+    MillibarsPerSecond = "MillibarPerSecond",
     /** */
-    MillibarsPerMinute
+    MillibarsPerMinute = "MillibarPerMinute"
 }
 
 /** Pressure change rate is the ratio of the pressure change to the time during which the change occurred (value of pressure changes per unit time). */

--- a/src/radiationequivalentdose.g.ts
+++ b/src/radiationequivalentdose.g.ts
@@ -1,17 +1,17 @@
 /** RadiationEquivalentDoseUnits enumeration */
 export enum RadiationEquivalentDoseUnits {
     /** The sievert is a unit in the International System of Units (SI) intended to represent the stochastic health risk of ionizing radiation, which is defined as the probability of causing radiation-induced cancer and genetic damage. */
-    Sieverts,
+    Sieverts = "Sievert",
     /** */
-    RoentgensEquivalentMan,
+    RoentgensEquivalentMan = "RoentgenEquivalentMan",
     /** */
-    Nanosieverts,
+    Nanosieverts = "Nanosievert",
     /** */
-    Microsieverts,
+    Microsieverts = "Microsievert",
     /** */
-    Millisieverts,
+    Millisieverts = "Millisievert",
     /** */
-    MilliroentgensEquivalentMan
+    MilliroentgensEquivalentMan = "MilliroentgenEquivalentMan"
 }
 
 /** Equivalent dose is a dose quantity representing the stochastic health effects of low levels of ionizing radiation on the human body which represents the probability of radiation-induced cancer and genetic damage. */

--- a/src/radiationexposure.g.ts
+++ b/src/radiationexposure.g.ts
@@ -1,21 +1,21 @@
 /** RadiationExposureUnits enumeration */
 export enum RadiationExposureUnits {
     /** */
-    CoulombsPerKilogram,
+    CoulombsPerKilogram = "CoulombPerKilogram",
     /** */
-    Roentgens,
+    Roentgens = "Roentgen",
     /** */
-    PicocoulombsPerKilogram,
+    PicocoulombsPerKilogram = "PicocoulombPerKilogram",
     /** */
-    NanocoulombsPerKilogram,
+    NanocoulombsPerKilogram = "NanocoulombPerKilogram",
     /** */
-    MicrocoulombsPerKilogram,
+    MicrocoulombsPerKilogram = "MicrocoulombPerKilogram",
     /** */
-    MillicoulombsPerKilogram,
+    MillicoulombsPerKilogram = "MillicoulombPerKilogram",
     /** */
-    Microroentgens,
+    Microroentgens = "Microroentgen",
     /** */
-    Milliroentgens
+    Milliroentgens = "Milliroentgen"
 }
 
 /** Radiation exposure is a measure of the ionization of air due to ionizing radiation from photons. */

--- a/src/radioactivity.g.ts
+++ b/src/radioactivity.g.ts
@@ -1,63 +1,63 @@
 /** RadioactivityUnits enumeration */
 export enum RadioactivityUnits {
     /** Activity of a quantity of radioactive material in which one nucleus decays per second. */
-    Becquerels,
+    Becquerels = "Becquerel",
     /** */
-    Curies,
+    Curies = "Curie",
     /** Activity of a quantity of radioactive material in which one million nuclei decay per second. */
-    Rutherfords,
+    Rutherfords = "Rutherford",
     /** */
-    Picobecquerels,
+    Picobecquerels = "Picobecquerel",
     /** */
-    Nanobecquerels,
+    Nanobecquerels = "Nanobecquerel",
     /** */
-    Microbecquerels,
+    Microbecquerels = "Microbecquerel",
     /** */
-    Millibecquerels,
+    Millibecquerels = "Millibecquerel",
     /** */
-    Kilobecquerels,
+    Kilobecquerels = "Kilobecquerel",
     /** */
-    Megabecquerels,
+    Megabecquerels = "Megabecquerel",
     /** */
-    Gigabecquerels,
+    Gigabecquerels = "Gigabecquerel",
     /** */
-    Terabecquerels,
+    Terabecquerels = "Terabecquerel",
     /** */
-    Petabecquerels,
+    Petabecquerels = "Petabecquerel",
     /** */
-    Exabecquerels,
+    Exabecquerels = "Exabecquerel",
     /** */
-    Picocuries,
+    Picocuries = "Picocurie",
     /** */
-    Nanocuries,
+    Nanocuries = "Nanocurie",
     /** */
-    Microcuries,
+    Microcuries = "Microcurie",
     /** */
-    Millicuries,
+    Millicuries = "Millicurie",
     /** */
-    Kilocuries,
+    Kilocuries = "Kilocurie",
     /** */
-    Megacuries,
+    Megacuries = "Megacurie",
     /** */
-    Gigacuries,
+    Gigacuries = "Gigacurie",
     /** */
-    Teracuries,
+    Teracuries = "Teracurie",
     /** */
-    Picorutherfords,
+    Picorutherfords = "Picorutherford",
     /** */
-    Nanorutherfords,
+    Nanorutherfords = "Nanorutherford",
     /** */
-    Microrutherfords,
+    Microrutherfords = "Microrutherford",
     /** */
-    Millirutherfords,
+    Millirutherfords = "Millirutherford",
     /** */
-    Kilorutherfords,
+    Kilorutherfords = "Kilorutherford",
     /** */
-    Megarutherfords,
+    Megarutherfords = "Megarutherford",
     /** */
-    Gigarutherfords,
+    Gigarutherfords = "Gigarutherford",
     /** */
-    Terarutherfords
+    Terarutherfords = "Terarutherford"
 }
 
 /** Amount of ionizing radiation released when an element spontaneously emits energy as a result of the radioactive decay of an unstable atom per unit time. */

--- a/src/ratio.g.ts
+++ b/src/ratio.g.ts
@@ -1,17 +1,17 @@
 /** RatioUnits enumeration */
 export enum RatioUnits {
     /** */
-    DecimalFractions,
+    DecimalFractions = "DecimalFraction",
     /** */
-    Percent,
+    Percent = "Percent",
     /** */
-    PartsPerThousand,
+    PartsPerThousand = "PartPerThousand",
     /** */
-    PartsPerMillion,
+    PartsPerMillion = "PartPerMillion",
     /** */
-    PartsPerBillion,
+    PartsPerBillion = "PartPerBillion",
     /** */
-    PartsPerTrillion
+    PartsPerTrillion = "PartPerTrillion"
 }
 
 /** In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer). */

--- a/src/ratiochangerate.g.ts
+++ b/src/ratiochangerate.g.ts
@@ -1,9 +1,9 @@
 /** RatioChangeRateUnits enumeration */
 export enum RatioChangeRateUnits {
     /** */
-    PercentsPerSecond,
+    PercentsPerSecond = "PercentPerSecond",
     /** */
-    DecimalFractionsPerSecond
+    DecimalFractionsPerSecond = "DecimalFractionPerSecond"
 }
 
 /** The change in ratio per unit of time. */

--- a/src/reactiveenergy.g.ts
+++ b/src/reactiveenergy.g.ts
@@ -1,11 +1,11 @@
 /** ReactiveEnergyUnits enumeration */
 export enum ReactiveEnergyUnits {
     /** */
-    VoltampereReactiveHours,
+    VoltampereReactiveHours = "VoltampereReactiveHour",
     /** */
-    KilovoltampereReactiveHours,
+    KilovoltampereReactiveHours = "KilovoltampereReactiveHour",
     /** */
-    MegavoltampereReactiveHours
+    MegavoltampereReactiveHours = "MegavoltampereReactiveHour"
 }
 
 /** The Volt-ampere reactive hour (expressed as varh) is the reactive power of one Volt-ampere reactive produced in one hour. */

--- a/src/reactivepower.g.ts
+++ b/src/reactivepower.g.ts
@@ -1,13 +1,13 @@
 /** ReactivePowerUnits enumeration */
 export enum ReactivePowerUnits {
     /** */
-    VoltamperesReactive,
+    VoltamperesReactive = "VoltampereReactive",
     /** */
-    KilovoltamperesReactive,
+    KilovoltamperesReactive = "KilovoltampereReactive",
     /** */
-    MegavoltamperesReactive,
+    MegavoltamperesReactive = "MegavoltampereReactive",
     /** */
-    GigavoltamperesReactive
+    GigavoltamperesReactive = "GigavoltampereReactive"
 }
 
 /** Volt-ampere reactive (var) is a unit by which reactive power is expressed in an AC electric power system. Reactive power exists in an AC circuit when the current and voltage are not in phase. */

--- a/src/reciprocalarea.g.ts
+++ b/src/reciprocalarea.g.ts
@@ -1,27 +1,27 @@
 /** ReciprocalAreaUnits enumeration */
 export enum ReciprocalAreaUnits {
     /** */
-    InverseSquareMeters,
+    InverseSquareMeters = "InverseSquareMeter",
     /** */
-    InverseSquareKilometers,
+    InverseSquareKilometers = "InverseSquareKilometer",
     /** */
-    InverseSquareDecimeters,
+    InverseSquareDecimeters = "InverseSquareDecimeter",
     /** */
-    InverseSquareCentimeters,
+    InverseSquareCentimeters = "InverseSquareCentimeter",
     /** */
-    InverseSquareMillimeters,
+    InverseSquareMillimeters = "InverseSquareMillimeter",
     /** */
-    InverseSquareMicrometers,
+    InverseSquareMicrometers = "InverseSquareMicrometer",
     /** */
-    InverseSquareMiles,
+    InverseSquareMiles = "InverseSquareMile",
     /** */
-    InverseSquareYards,
+    InverseSquareYards = "InverseSquareYard",
     /** */
-    InverseSquareFeet,
+    InverseSquareFeet = "InverseSquareFoot",
     /** */
-    InverseUsSurveySquareFeet,
+    InverseUsSurveySquareFeet = "InverseUsSurveySquareFoot",
     /** */
-    InverseSquareInches
+    InverseSquareInches = "InverseSquareInch"
 }
 
 /** Reciprocal area (Inverse-square) quantity is used to specify a physical quantity inversely proportional to the square of the distance. */

--- a/src/reciprocallength.g.ts
+++ b/src/reciprocallength.g.ts
@@ -1,25 +1,25 @@
 /** ReciprocalLengthUnits enumeration */
 export enum ReciprocalLengthUnits {
     /** */
-    InverseMeters,
+    InverseMeters = "InverseMeter",
     /** */
-    InverseCentimeters,
+    InverseCentimeters = "InverseCentimeter",
     /** */
-    InverseMillimeters,
+    InverseMillimeters = "InverseMillimeter",
     /** */
-    InverseMiles,
+    InverseMiles = "InverseMile",
     /** */
-    InverseYards,
+    InverseYards = "InverseYard",
     /** */
-    InverseFeet,
+    InverseFeet = "InverseFoot",
     /** */
-    InverseUsSurveyFeet,
+    InverseUsSurveyFeet = "InverseUsSurveyFoot",
     /** */
-    InverseInches,
+    InverseInches = "InverseInch",
     /** */
-    InverseMils,
+    InverseMils = "InverseMil",
     /** */
-    InverseMicroinches
+    InverseMicroinches = "InverseMicroinch"
 }
 
 /** Reciprocal (Inverse) Length is used in various fields of science and mathematics. It is defined as the inverse value of a length unit. */

--- a/src/relativehumidity.g.ts
+++ b/src/relativehumidity.g.ts
@@ -1,7 +1,7 @@
 /** RelativeHumidityUnits enumeration */
 export enum RelativeHumidityUnits {
     /** */
-    Percent
+    Percent = "Percent"
 }
 
 /** Relative humidity is a ratio of the actual water vapor present in the air to the maximum water vapor in the air at the given temperature. */

--- a/src/rotationalacceleration.g.ts
+++ b/src/rotationalacceleration.g.ts
@@ -1,13 +1,13 @@
 /** RotationalAccelerationUnits enumeration */
 export enum RotationalAccelerationUnits {
     /** */
-    RadiansPerSecondSquared,
+    RadiansPerSecondSquared = "RadianPerSecondSquared",
     /** */
-    DegreesPerSecondSquared,
+    DegreesPerSecondSquared = "DegreePerSecondSquared",
     /** */
-    RevolutionsPerMinutePerSecond,
+    RevolutionsPerMinutePerSecond = "RevolutionPerMinutePerSecond",
     /** */
-    RevolutionsPerSecondSquared
+    RevolutionsPerSecondSquared = "RevolutionPerSecondSquared"
 }
 
 /** Angular acceleration is the rate of change of rotational speed. */

--- a/src/rotationalspeed.g.ts
+++ b/src/rotationalspeed.g.ts
@@ -1,31 +1,31 @@
 /** RotationalSpeedUnits enumeration */
 export enum RotationalSpeedUnits {
     /** */
-    RadiansPerSecond,
+    RadiansPerSecond = "RadianPerSecond",
     /** */
-    DegreesPerSecond,
+    DegreesPerSecond = "DegreePerSecond",
     /** */
-    DegreesPerMinute,
+    DegreesPerMinute = "DegreePerMinute",
     /** */
-    RevolutionsPerSecond,
+    RevolutionsPerSecond = "RevolutionPerSecond",
     /** */
-    RevolutionsPerMinute,
+    RevolutionsPerMinute = "RevolutionPerMinute",
     /** */
-    NanoradiansPerSecond,
+    NanoradiansPerSecond = "NanoradianPerSecond",
     /** */
-    MicroradiansPerSecond,
+    MicroradiansPerSecond = "MicroradianPerSecond",
     /** */
-    MilliradiansPerSecond,
+    MilliradiansPerSecond = "MilliradianPerSecond",
     /** */
-    CentiradiansPerSecond,
+    CentiradiansPerSecond = "CentiradianPerSecond",
     /** */
-    DeciradiansPerSecond,
+    DeciradiansPerSecond = "DeciradianPerSecond",
     /** */
-    NanodegreesPerSecond,
+    NanodegreesPerSecond = "NanodegreePerSecond",
     /** */
-    MicrodegreesPerSecond,
+    MicrodegreesPerSecond = "MicrodegreePerSecond",
     /** */
-    MillidegreesPerSecond
+    MillidegreesPerSecond = "MillidegreePerSecond"
 }
 
 /** Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega"). */

--- a/src/rotationalstiffness.g.ts
+++ b/src/rotationalstiffness.g.ts
@@ -1,71 +1,71 @@
 /** RotationalStiffnessUnits enumeration */
 export enum RotationalStiffnessUnits {
     /** */
-    NewtonMetersPerRadian,
+    NewtonMetersPerRadian = "NewtonMeterPerRadian",
     /** */
-    PoundForceFeetPerDegrees,
+    PoundForceFeetPerDegrees = "PoundForceFootPerDegrees",
     /** */
-    KilopoundForceFeetPerDegrees,
+    KilopoundForceFeetPerDegrees = "KilopoundForceFootPerDegrees",
     /** */
-    NewtonMillimetersPerDegree,
+    NewtonMillimetersPerDegree = "NewtonMillimeterPerDegree",
     /** */
-    NewtonMetersPerDegree,
+    NewtonMetersPerDegree = "NewtonMeterPerDegree",
     /** */
-    NewtonMillimetersPerRadian,
+    NewtonMillimetersPerRadian = "NewtonMillimeterPerRadian",
     /** */
-    PoundForceFeetPerRadian,
+    PoundForceFeetPerRadian = "PoundForceFeetPerRadian",
     /** */
-    KilonewtonMetersPerRadian,
+    KilonewtonMetersPerRadian = "KilonewtonMeterPerRadian",
     /** */
-    MeganewtonMetersPerRadian,
+    MeganewtonMetersPerRadian = "MeganewtonMeterPerRadian",
     /** */
-    NanonewtonMillimetersPerDegree,
+    NanonewtonMillimetersPerDegree = "NanonewtonMillimeterPerDegree",
     /** */
-    MicronewtonMillimetersPerDegree,
+    MicronewtonMillimetersPerDegree = "MicronewtonMillimeterPerDegree",
     /** */
-    MillinewtonMillimetersPerDegree,
+    MillinewtonMillimetersPerDegree = "MillinewtonMillimeterPerDegree",
     /** */
-    CentinewtonMillimetersPerDegree,
+    CentinewtonMillimetersPerDegree = "CentinewtonMillimeterPerDegree",
     /** */
-    DecinewtonMillimetersPerDegree,
+    DecinewtonMillimetersPerDegree = "DecinewtonMillimeterPerDegree",
     /** */
-    DecanewtonMillimetersPerDegree,
+    DecanewtonMillimetersPerDegree = "DecanewtonMillimeterPerDegree",
     /** */
-    KilonewtonMillimetersPerDegree,
+    KilonewtonMillimetersPerDegree = "KilonewtonMillimeterPerDegree",
     /** */
-    MeganewtonMillimetersPerDegree,
+    MeganewtonMillimetersPerDegree = "MeganewtonMillimeterPerDegree",
     /** */
-    NanonewtonMetersPerDegree,
+    NanonewtonMetersPerDegree = "NanonewtonMeterPerDegree",
     /** */
-    MicronewtonMetersPerDegree,
+    MicronewtonMetersPerDegree = "MicronewtonMeterPerDegree",
     /** */
-    MillinewtonMetersPerDegree,
+    MillinewtonMetersPerDegree = "MillinewtonMeterPerDegree",
     /** */
-    CentinewtonMetersPerDegree,
+    CentinewtonMetersPerDegree = "CentinewtonMeterPerDegree",
     /** */
-    DecinewtonMetersPerDegree,
+    DecinewtonMetersPerDegree = "DecinewtonMeterPerDegree",
     /** */
-    DecanewtonMetersPerDegree,
+    DecanewtonMetersPerDegree = "DecanewtonMeterPerDegree",
     /** */
-    KilonewtonMetersPerDegree,
+    KilonewtonMetersPerDegree = "KilonewtonMeterPerDegree",
     /** */
-    MeganewtonMetersPerDegree,
+    MeganewtonMetersPerDegree = "MeganewtonMeterPerDegree",
     /** */
-    NanonewtonMillimetersPerRadian,
+    NanonewtonMillimetersPerRadian = "NanonewtonMillimeterPerRadian",
     /** */
-    MicronewtonMillimetersPerRadian,
+    MicronewtonMillimetersPerRadian = "MicronewtonMillimeterPerRadian",
     /** */
-    MillinewtonMillimetersPerRadian,
+    MillinewtonMillimetersPerRadian = "MillinewtonMillimeterPerRadian",
     /** */
-    CentinewtonMillimetersPerRadian,
+    CentinewtonMillimetersPerRadian = "CentinewtonMillimeterPerRadian",
     /** */
-    DecinewtonMillimetersPerRadian,
+    DecinewtonMillimetersPerRadian = "DecinewtonMillimeterPerRadian",
     /** */
-    DecanewtonMillimetersPerRadian,
+    DecanewtonMillimetersPerRadian = "DecanewtonMillimeterPerRadian",
     /** */
-    KilonewtonMillimetersPerRadian,
+    KilonewtonMillimetersPerRadian = "KilonewtonMillimeterPerRadian",
     /** */
-    MeganewtonMillimetersPerRadian
+    MeganewtonMillimetersPerRadian = "MeganewtonMillimeterPerRadian"
 }
 
 /** https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness */

--- a/src/rotationalstiffnessperlength.g.ts
+++ b/src/rotationalstiffnessperlength.g.ts
@@ -1,15 +1,15 @@
 /** RotationalStiffnessPerLengthUnits enumeration */
 export enum RotationalStiffnessPerLengthUnits {
     /** */
-    NewtonMetersPerRadianPerMeter,
+    NewtonMetersPerRadianPerMeter = "NewtonMeterPerRadianPerMeter",
     /** */
-    PoundForceFeetPerDegreesPerFeet,
+    PoundForceFeetPerDegreesPerFeet = "PoundForceFootPerDegreesPerFoot",
     /** */
-    KilopoundForceFeetPerDegreesPerFeet,
+    KilopoundForceFeetPerDegreesPerFeet = "KilopoundForceFootPerDegreesPerFoot",
     /** */
-    KilonewtonMetersPerRadianPerMeter,
+    KilonewtonMetersPerRadianPerMeter = "KilonewtonMeterPerRadianPerMeter",
     /** */
-    MeganewtonMetersPerRadianPerMeter
+    MeganewtonMetersPerRadianPerMeter = "MeganewtonMeterPerRadianPerMeter"
 }
 
 /** https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness */

--- a/src/scalar.g.ts
+++ b/src/scalar.g.ts
@@ -1,7 +1,7 @@
 /** ScalarUnits enumeration */
 export enum ScalarUnits {
     /** */
-    Amount
+    Amount = "Amount"
 }
 
 /** A way of representing a number of items. */

--- a/src/solidangle.g.ts
+++ b/src/solidangle.g.ts
@@ -1,7 +1,7 @@
 /** SolidAngleUnits enumeration */
 export enum SolidAngleUnits {
     /** */
-    Steradians
+    Steradians = "Steradian"
 }
 
 /** In geometry, a solid angle is the two-dimensional angle in three-dimensional space that an object subtends at a point. */

--- a/src/specificenergy.g.ts
+++ b/src/specificenergy.g.ts
@@ -1,65 +1,65 @@
 /** SpecificEnergyUnits enumeration */
 export enum SpecificEnergyUnits {
     /** */
-    JoulesPerKilogram,
+    JoulesPerKilogram = "JoulePerKilogram",
     /** */
-    MegaJoulesPerTonne,
+    MegaJoulesPerTonne = "MegaJoulePerTonne",
     /** */
-    CaloriesPerGram,
+    CaloriesPerGram = "CaloriePerGram",
     /** */
-    WattHoursPerKilogram,
+    WattHoursPerKilogram = "WattHourPerKilogram",
     /** */
-    WattDaysPerKilogram,
+    WattDaysPerKilogram = "WattDayPerKilogram",
     /** */
-    WattDaysPerTonne,
+    WattDaysPerTonne = "WattDayPerTonne",
     /** */
-    WattDaysPerShortTon,
+    WattDaysPerShortTon = "WattDayPerShortTon",
     /** */
-    WattHoursPerPound,
+    WattHoursPerPound = "WattHourPerPound",
     /** */
-    BtuPerPound,
+    BtuPerPound = "BtuPerPound",
     /** */
-    KilojoulesPerKilogram,
+    KilojoulesPerKilogram = "KilojoulePerKilogram",
     /** */
-    MegajoulesPerKilogram,
+    MegajoulesPerKilogram = "MegajoulePerKilogram",
     /** */
-    KilocaloriesPerGram,
+    KilocaloriesPerGram = "KilocaloriePerGram",
     /** */
-    KilowattHoursPerKilogram,
+    KilowattHoursPerKilogram = "KilowattHourPerKilogram",
     /** */
-    MegawattHoursPerKilogram,
+    MegawattHoursPerKilogram = "MegawattHourPerKilogram",
     /** */
-    GigawattHoursPerKilogram,
+    GigawattHoursPerKilogram = "GigawattHourPerKilogram",
     /** */
-    KilowattDaysPerKilogram,
+    KilowattDaysPerKilogram = "KilowattDayPerKilogram",
     /** */
-    MegawattDaysPerKilogram,
+    MegawattDaysPerKilogram = "MegawattDayPerKilogram",
     /** */
-    GigawattDaysPerKilogram,
+    GigawattDaysPerKilogram = "GigawattDayPerKilogram",
     /** */
-    TerawattDaysPerKilogram,
+    TerawattDaysPerKilogram = "TerawattDayPerKilogram",
     /** */
-    KilowattDaysPerTonne,
+    KilowattDaysPerTonne = "KilowattDayPerTonne",
     /** */
-    MegawattDaysPerTonne,
+    MegawattDaysPerTonne = "MegawattDayPerTonne",
     /** */
-    GigawattDaysPerTonne,
+    GigawattDaysPerTonne = "GigawattDayPerTonne",
     /** */
-    TerawattDaysPerTonne,
+    TerawattDaysPerTonne = "TerawattDayPerTonne",
     /** */
-    KilowattDaysPerShortTon,
+    KilowattDaysPerShortTon = "KilowattDayPerShortTon",
     /** */
-    MegawattDaysPerShortTon,
+    MegawattDaysPerShortTon = "MegawattDayPerShortTon",
     /** */
-    GigawattDaysPerShortTon,
+    GigawattDaysPerShortTon = "GigawattDayPerShortTon",
     /** */
-    TerawattDaysPerShortTon,
+    TerawattDaysPerShortTon = "TerawattDayPerShortTon",
     /** */
-    KilowattHoursPerPound,
+    KilowattHoursPerPound = "KilowattHourPerPound",
     /** */
-    MegawattHoursPerPound,
+    MegawattHoursPerPound = "MegawattHourPerPound",
     /** */
-    GigawattHoursPerPound
+    GigawattHoursPerPound = "GigawattHourPerPound"
 }
 
 /** The SpecificEnergy */

--- a/src/specificentropy.g.ts
+++ b/src/specificentropy.g.ts
@@ -1,23 +1,23 @@
 /** SpecificEntropyUnits enumeration */
 export enum SpecificEntropyUnits {
     /** */
-    JoulesPerKilogramKelvin,
+    JoulesPerKilogramKelvin = "JoulePerKilogramKelvin",
     /** */
-    JoulesPerKilogramDegreeCelsius,
+    JoulesPerKilogramDegreeCelsius = "JoulePerKilogramDegreeCelsius",
     /** */
-    CaloriesPerGramKelvin,
+    CaloriesPerGramKelvin = "CaloriePerGramKelvin",
     /** */
-    BtusPerPoundFahrenheit,
+    BtusPerPoundFahrenheit = "BtuPerPoundFahrenheit",
     /** */
-    KilojoulesPerKilogramKelvin,
+    KilojoulesPerKilogramKelvin = "KilojoulePerKilogramKelvin",
     /** */
-    MegajoulesPerKilogramKelvin,
+    MegajoulesPerKilogramKelvin = "MegajoulePerKilogramKelvin",
     /** */
-    KilojoulesPerKilogramDegreeCelsius,
+    KilojoulesPerKilogramDegreeCelsius = "KilojoulePerKilogramDegreeCelsius",
     /** */
-    MegajoulesPerKilogramDegreeCelsius,
+    MegajoulesPerKilogramDegreeCelsius = "MegajoulePerKilogramDegreeCelsius",
     /** */
-    KilocaloriesPerGramKelvin
+    KilocaloriesPerGramKelvin = "KilocaloriePerGramKelvin"
 }
 
 /** Specific entropy is an amount of energy required to raise temperature of a substance by 1 Kelvin per unit mass. */

--- a/src/specificfuelconsumption.g.ts
+++ b/src/specificfuelconsumption.g.ts
@@ -1,13 +1,13 @@
 /** SpecificFuelConsumptionUnits enumeration */
 export enum SpecificFuelConsumptionUnits {
     /** */
-    PoundsMassPerPoundForceHour,
+    PoundsMassPerPoundForceHour = "PoundMassPerPoundForceHour",
     /** */
-    KilogramsPerKilogramForceHour,
+    KilogramsPerKilogramForceHour = "KilogramPerKilogramForceHour",
     /** */
-    GramsPerKiloNewtonSecond,
+    GramsPerKiloNewtonSecond = "GramPerKiloNewtonSecond",
     /** */
-    KilogramsPerKiloNewtonSecond
+    KilogramsPerKiloNewtonSecond = "KilogramPerKiloNewtonSecond"
 }
 
 /** SFC is the fuel efficiency of an engine design with respect to thrust output */

--- a/src/specificvolume.g.ts
+++ b/src/specificvolume.g.ts
@@ -1,11 +1,11 @@
 /** SpecificVolumeUnits enumeration */
 export enum SpecificVolumeUnits {
     /** */
-    CubicMetersPerKilogram,
+    CubicMetersPerKilogram = "CubicMeterPerKilogram",
     /** */
-    CubicFeetPerPound,
+    CubicFeetPerPound = "CubicFootPerPound",
     /** */
-    MillicubicMetersPerKilogram
+    MillicubicMetersPerKilogram = "MillicubicMeterPerKilogram"
 }
 
 /** In thermodynamics, the specific volume of a substance is the ratio of the substance's volume to its mass. It is the reciprocal of density and an intrinsic property of matter as well. */

--- a/src/specificweight.g.ts
+++ b/src/specificweight.g.ts
@@ -1,39 +1,39 @@
 /** SpecificWeightUnits enumeration */
 export enum SpecificWeightUnits {
     /** */
-    NewtonsPerCubicMillimeter,
+    NewtonsPerCubicMillimeter = "NewtonPerCubicMillimeter",
     /** */
-    NewtonsPerCubicCentimeter,
+    NewtonsPerCubicCentimeter = "NewtonPerCubicCentimeter",
     /** */
-    NewtonsPerCubicMeter,
+    NewtonsPerCubicMeter = "NewtonPerCubicMeter",
     /** */
-    KilogramsForcePerCubicMillimeter,
+    KilogramsForcePerCubicMillimeter = "KilogramForcePerCubicMillimeter",
     /** */
-    KilogramsForcePerCubicCentimeter,
+    KilogramsForcePerCubicCentimeter = "KilogramForcePerCubicCentimeter",
     /** */
-    KilogramsForcePerCubicMeter,
+    KilogramsForcePerCubicMeter = "KilogramForcePerCubicMeter",
     /** */
-    PoundsForcePerCubicInch,
+    PoundsForcePerCubicInch = "PoundForcePerCubicInch",
     /** */
-    PoundsForcePerCubicFoot,
+    PoundsForcePerCubicFoot = "PoundForcePerCubicFoot",
     /** */
-    TonnesForcePerCubicMillimeter,
+    TonnesForcePerCubicMillimeter = "TonneForcePerCubicMillimeter",
     /** */
-    TonnesForcePerCubicCentimeter,
+    TonnesForcePerCubicCentimeter = "TonneForcePerCubicCentimeter",
     /** */
-    TonnesForcePerCubicMeter,
+    TonnesForcePerCubicMeter = "TonneForcePerCubicMeter",
     /** */
-    KilonewtonsPerCubicMillimeter,
+    KilonewtonsPerCubicMillimeter = "KilonewtonPerCubicMillimeter",
     /** */
-    KilonewtonsPerCubicCentimeter,
+    KilonewtonsPerCubicCentimeter = "KilonewtonPerCubicCentimeter",
     /** */
-    KilonewtonsPerCubicMeter,
+    KilonewtonsPerCubicMeter = "KilonewtonPerCubicMeter",
     /** */
-    MeganewtonsPerCubicMeter,
+    MeganewtonsPerCubicMeter = "MeganewtonPerCubicMeter",
     /** */
-    KilopoundsForcePerCubicInch,
+    KilopoundsForcePerCubicInch = "KilopoundForcePerCubicInch",
     /** */
-    KilopoundsForcePerCubicFoot
+    KilopoundsForcePerCubicFoot = "KilopoundForcePerCubicFoot"
 }
 
 /** The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume. */

--- a/src/speed.g.ts
+++ b/src/speed.g.ts
@@ -1,71 +1,71 @@
 /** SpeedUnits enumeration */
 export enum SpeedUnits {
     /** */
-    MetersPerSecond,
+    MetersPerSecond = "MeterPerSecond",
     /** */
-    MetersPerMinutes,
+    MetersPerMinutes = "MeterPerMinute",
     /** */
-    MetersPerHour,
+    MetersPerHour = "MeterPerHour",
     /** */
-    FeetPerSecond,
+    FeetPerSecond = "FootPerSecond",
     /** */
-    FeetPerMinute,
+    FeetPerMinute = "FootPerMinute",
     /** */
-    FeetPerHour,
+    FeetPerHour = "FootPerHour",
     /** */
-    UsSurveyFeetPerSecond,
+    UsSurveyFeetPerSecond = "UsSurveyFootPerSecond",
     /** */
-    UsSurveyFeetPerMinute,
+    UsSurveyFeetPerMinute = "UsSurveyFootPerMinute",
     /** */
-    UsSurveyFeetPerHour,
+    UsSurveyFeetPerHour = "UsSurveyFootPerHour",
     /** */
-    InchesPerSecond,
+    InchesPerSecond = "InchPerSecond",
     /** */
-    InchesPerMinute,
+    InchesPerMinute = "InchPerMinute",
     /** */
-    InchesPerHour,
+    InchesPerHour = "InchPerHour",
     /** */
-    YardsPerSecond,
+    YardsPerSecond = "YardPerSecond",
     /** */
-    YardsPerMinute,
+    YardsPerMinute = "YardPerMinute",
     /** */
-    YardsPerHour,
+    YardsPerHour = "YardPerHour",
     /** The knot, by definition, is a unit of speed equals to 1 nautical mile per hour, which is exactly 1852.000 metres per hour. The length of the internationally agreed nautical mile is 1852 m. The US adopted the international definition in 1954, the UK adopted the international nautical mile definition in 1970. */
-    Knots,
+    Knots = "Knot",
     /** */
-    MilesPerHour,
+    MilesPerHour = "MilePerHour",
     /** */
-    Mach,
+    Mach = "Mach",
     /** */
-    NanometersPerSecond,
+    NanometersPerSecond = "NanometerPerSecond",
     /** */
-    MicrometersPerSecond,
+    MicrometersPerSecond = "MicrometerPerSecond",
     /** */
-    MillimetersPerSecond,
+    MillimetersPerSecond = "MillimeterPerSecond",
     /** */
-    CentimetersPerSecond,
+    CentimetersPerSecond = "CentimeterPerSecond",
     /** */
-    DecimetersPerSecond,
+    DecimetersPerSecond = "DecimeterPerSecond",
     /** */
-    KilometersPerSecond,
+    KilometersPerSecond = "KilometerPerSecond",
     /** */
-    NanometersPerMinutes,
+    NanometersPerMinutes = "NanometerPerMinute",
     /** */
-    MicrometersPerMinutes,
+    MicrometersPerMinutes = "MicrometerPerMinute",
     /** */
-    MillimetersPerMinutes,
+    MillimetersPerMinutes = "MillimeterPerMinute",
     /** */
-    CentimetersPerMinutes,
+    CentimetersPerMinutes = "CentimeterPerMinute",
     /** */
-    DecimetersPerMinutes,
+    DecimetersPerMinutes = "DecimeterPerMinute",
     /** */
-    KilometersPerMinutes,
+    KilometersPerMinutes = "KilometerPerMinute",
     /** */
-    MillimetersPerHour,
+    MillimetersPerHour = "MillimeterPerHour",
     /** */
-    CentimetersPerHour,
+    CentimetersPerHour = "CentimeterPerHour",
     /** */
-    KilometersPerHour
+    KilometersPerHour = "KilometerPerHour"
 }
 
 /** In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero. */

--- a/src/standardvolumeflow.g.ts
+++ b/src/standardvolumeflow.g.ts
@@ -1,23 +1,23 @@
 /** StandardVolumeFlowUnits enumeration */
 export enum StandardVolumeFlowUnits {
     /** */
-    StandardCubicMetersPerSecond,
+    StandardCubicMetersPerSecond = "StandardCubicMeterPerSecond",
     /** */
-    StandardCubicMetersPerMinute,
+    StandardCubicMetersPerMinute = "StandardCubicMeterPerMinute",
     /** */
-    StandardCubicMetersPerHour,
+    StandardCubicMetersPerHour = "StandardCubicMeterPerHour",
     /** */
-    StandardCubicMetersPerDay,
+    StandardCubicMetersPerDay = "StandardCubicMeterPerDay",
     /** */
-    StandardCubicCentimetersPerMinute,
+    StandardCubicCentimetersPerMinute = "StandardCubicCentimeterPerMinute",
     /** */
-    StandardLitersPerMinute,
+    StandardLitersPerMinute = "StandardLiterPerMinute",
     /** */
-    StandardCubicFeetPerSecond,
+    StandardCubicFeetPerSecond = "StandardCubicFootPerSecond",
     /** */
-    StandardCubicFeetPerMinute,
+    StandardCubicFeetPerMinute = "StandardCubicFootPerMinute",
     /** */
-    StandardCubicFeetPerHour
+    StandardCubicFeetPerHour = "StandardCubicFootPerHour"
 }
 
 /** The molar flow rate of a gas corrected to standardized conditions of temperature and pressure thus representing a fixed number of moles of gas regardless of composition and actual flow conditions. */

--- a/src/temperature.g.ts
+++ b/src/temperature.g.ts
@@ -1,25 +1,25 @@
 /** TemperatureUnits enumeration */
 export enum TemperatureUnits {
     /** */
-    Kelvins,
+    Kelvins = "Kelvin",
     /** */
-    DegreesCelsius,
+    DegreesCelsius = "DegreeCelsius",
     /** */
-    MillidegreesCelsius,
+    MillidegreesCelsius = "MillidegreeCelsius",
     /** */
-    DegreesDelisle,
+    DegreesDelisle = "DegreeDelisle",
     /** */
-    DegreesFahrenheit,
+    DegreesFahrenheit = "DegreeFahrenheit",
     /** */
-    DegreesNewton,
+    DegreesNewton = "DegreeNewton",
     /** */
-    DegreesRankine,
+    DegreesRankine = "DegreeRankine",
     /** */
-    DegreesReaumur,
+    DegreesReaumur = "DegreeReaumur",
     /** */
-    DegreesRoemer,
+    DegreesRoemer = "DegreeRoemer",
     /** */
-    SolarTemperatures
+    SolarTemperatures = "SolarTemperature"
 }
 
 /** A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics. */

--- a/src/temperaturechangerate.g.ts
+++ b/src/temperaturechangerate.g.ts
@@ -1,25 +1,25 @@
 /** TemperatureChangeRateUnits enumeration */
 export enum TemperatureChangeRateUnits {
     /** */
-    DegreesCelsiusPerSecond,
+    DegreesCelsiusPerSecond = "DegreeCelsiusPerSecond",
     /** */
-    DegreesCelsiusPerMinute,
+    DegreesCelsiusPerMinute = "DegreeCelsiusPerMinute",
     /** */
-    NanodegreesCelsiusPerSecond,
+    NanodegreesCelsiusPerSecond = "NanodegreeCelsiusPerSecond",
     /** */
-    MicrodegreesCelsiusPerSecond,
+    MicrodegreesCelsiusPerSecond = "MicrodegreeCelsiusPerSecond",
     /** */
-    MillidegreesCelsiusPerSecond,
+    MillidegreesCelsiusPerSecond = "MillidegreeCelsiusPerSecond",
     /** */
-    CentidegreesCelsiusPerSecond,
+    CentidegreesCelsiusPerSecond = "CentidegreeCelsiusPerSecond",
     /** */
-    DecidegreesCelsiusPerSecond,
+    DecidegreesCelsiusPerSecond = "DecidegreeCelsiusPerSecond",
     /** */
-    DecadegreesCelsiusPerSecond,
+    DecadegreesCelsiusPerSecond = "DecadegreeCelsiusPerSecond",
     /** */
-    HectodegreesCelsiusPerSecond,
+    HectodegreesCelsiusPerSecond = "HectodegreeCelsiusPerSecond",
     /** */
-    KilodegreesCelsiusPerSecond
+    KilodegreesCelsiusPerSecond = "KilodegreeCelsiusPerSecond"
 }
 
 /** Temperature change rate is the ratio of the temperature change to the time during which the change occurred (value of temperature changes per unit time). */

--- a/src/temperaturedelta.g.ts
+++ b/src/temperaturedelta.g.ts
@@ -1,23 +1,23 @@
 /** TemperatureDeltaUnits enumeration */
 export enum TemperatureDeltaUnits {
     /** */
-    Kelvins,
+    Kelvins = "Kelvin",
     /** */
-    DegreesCelsius,
+    DegreesCelsius = "DegreeCelsius",
     /** */
-    DegreesDelisle,
+    DegreesDelisle = "DegreeDelisle",
     /** */
-    DegreesFahrenheit,
+    DegreesFahrenheit = "DegreeFahrenheit",
     /** */
-    DegreesNewton,
+    DegreesNewton = "DegreeNewton",
     /** */
-    DegreesRankine,
+    DegreesRankine = "DegreeRankine",
     /** */
-    DegreesReaumur,
+    DegreesReaumur = "DegreeReaumur",
     /** */
-    DegreesRoemer,
+    DegreesRoemer = "DegreeRoemer",
     /** */
-    MillidegreesCelsius
+    MillidegreesCelsius = "MillidegreeCelsius"
 }
 
 /** Difference between two temperatures. The conversions are different than for Temperature. */

--- a/src/temperaturegradient.g.ts
+++ b/src/temperaturegradient.g.ts
@@ -1,13 +1,13 @@
 /** TemperatureGradientUnits enumeration */
 export enum TemperatureGradientUnits {
     /** */
-    KelvinsPerMeter,
+    KelvinsPerMeter = "KelvinPerMeter",
     /** */
-    DegreesCelciusPerMeter,
+    DegreesCelciusPerMeter = "DegreeCelsiusPerMeter",
     /** */
-    DegreesFahrenheitPerFoot,
+    DegreesFahrenheitPerFoot = "DegreeFahrenheitPerFoot",
     /** */
-    DegreesCelciusPerKilometer
+    DegreesCelciusPerKilometer = "DegreeCelsiusPerKilometer"
 }
 
 /** The rate of change of temperature with displacement in a given direction (as with increase of height) */

--- a/src/thermalconductivity.g.ts
+++ b/src/thermalconductivity.g.ts
@@ -1,9 +1,9 @@
 /** ThermalConductivityUnits enumeration */
 export enum ThermalConductivityUnits {
     /** */
-    WattsPerMeterKelvin,
+    WattsPerMeterKelvin = "WattPerMeterKelvin",
     /** */
-    BtusPerHourFootFahrenheit
+    BtusPerHourFootFahrenheit = "BtuPerHourFootFahrenheit"
 }
 
 /** Thermal conductivity is the property of a material to conduct heat. */

--- a/src/thermalresistance.g.ts
+++ b/src/thermalresistance.g.ts
@@ -1,17 +1,17 @@
 /** ThermalResistanceUnits enumeration */
 export enum ThermalResistanceUnits {
     /** */
-    SquareMeterKelvinsPerKilowatt,
+    SquareMeterKelvinsPerKilowatt = "SquareMeterKelvinPerKilowatt",
     /** */
-    SquareMeterKelvinsPerWatt,
+    SquareMeterKelvinsPerWatt = "SquareMeterKelvinPerWatt",
     /** */
-    SquareMeterDegreesCelsiusPerWatt,
+    SquareMeterDegreesCelsiusPerWatt = "SquareMeterDegreeCelsiusPerWatt",
     /** */
-    SquareCentimeterKelvinsPerWatt,
+    SquareCentimeterKelvinsPerWatt = "SquareCentimeterKelvinPerWatt",
     /** */
-    SquareCentimeterHourDegreesCelsiusPerKilocalorie,
+    SquareCentimeterHourDegreesCelsiusPerKilocalorie = "SquareCentimeterHourDegreeCelsiusPerKilocalorie",
     /** */
-    HourSquareFeetDegreesFahrenheitPerBtu
+    HourSquareFeetDegreesFahrenheitPerBtu = "HourSquareFeetDegreeFahrenheitPerBtu"
 }
 
 /** Heat Transfer Coefficient or Thermal conductivity - indicates a materials ability to conduct heat. */

--- a/src/torque.g.ts
+++ b/src/torque.g.ts
@@ -1,55 +1,55 @@
 /** TorqueUnits enumeration */
 export enum TorqueUnits {
     /** */
-    NewtonMillimeters,
+    NewtonMillimeters = "NewtonMillimeter",
     /** */
-    NewtonCentimeters,
+    NewtonCentimeters = "NewtonCentimeter",
     /** */
-    NewtonMeters,
+    NewtonMeters = "NewtonMeter",
     /** */
-    PoundalFeet,
+    PoundalFeet = "PoundalFoot",
     /** */
-    PoundForceInches,
+    PoundForceInches = "PoundForceInch",
     /** */
-    PoundForceFeet,
+    PoundForceFeet = "PoundForceFoot",
     /** */
-    GramForceMillimeters,
+    GramForceMillimeters = "GramForceMillimeter",
     /** */
-    GramForceCentimeters,
+    GramForceCentimeters = "GramForceCentimeter",
     /** */
-    GramForceMeters,
+    GramForceMeters = "GramForceMeter",
     /** */
-    KilogramForceMillimeters,
+    KilogramForceMillimeters = "KilogramForceMillimeter",
     /** */
-    KilogramForceCentimeters,
+    KilogramForceCentimeters = "KilogramForceCentimeter",
     /** */
-    KilogramForceMeters,
+    KilogramForceMeters = "KilogramForceMeter",
     /** */
-    TonneForceMillimeters,
+    TonneForceMillimeters = "TonneForceMillimeter",
     /** */
-    TonneForceCentimeters,
+    TonneForceCentimeters = "TonneForceCentimeter",
     /** */
-    TonneForceMeters,
+    TonneForceMeters = "TonneForceMeter",
     /** */
-    KilonewtonMillimeters,
+    KilonewtonMillimeters = "KilonewtonMillimeter",
     /** */
-    MeganewtonMillimeters,
+    MeganewtonMillimeters = "MeganewtonMillimeter",
     /** */
-    KilonewtonCentimeters,
+    KilonewtonCentimeters = "KilonewtonCentimeter",
     /** */
-    MeganewtonCentimeters,
+    MeganewtonCentimeters = "MeganewtonCentimeter",
     /** */
-    KilonewtonMeters,
+    KilonewtonMeters = "KilonewtonMeter",
     /** */
-    MeganewtonMeters,
+    MeganewtonMeters = "MeganewtonMeter",
     /** */
-    KilopoundForceInches,
+    KilopoundForceInches = "KilopoundForceInch",
     /** */
-    MegapoundForceInches,
+    MegapoundForceInches = "MegapoundForceInch",
     /** */
-    KilopoundForceFeet,
+    KilopoundForceFeet = "KilopoundForceFoot",
     /** */
-    MegapoundForceFeet
+    MegapoundForceFeet = "MegapoundForceFoot"
 }
 
 /** Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt. */

--- a/src/torqueperlength.g.ts
+++ b/src/torqueperlength.g.ts
@@ -1,47 +1,47 @@
 /** TorquePerLengthUnits enumeration */
 export enum TorquePerLengthUnits {
     /** */
-    NewtonMillimetersPerMeter,
+    NewtonMillimetersPerMeter = "NewtonMillimeterPerMeter",
     /** */
-    NewtonCentimetersPerMeter,
+    NewtonCentimetersPerMeter = "NewtonCentimeterPerMeter",
     /** */
-    NewtonMetersPerMeter,
+    NewtonMetersPerMeter = "NewtonMeterPerMeter",
     /** */
-    PoundForceInchesPerFoot,
+    PoundForceInchesPerFoot = "PoundForceInchPerFoot",
     /** */
-    PoundForceFeetPerFoot,
+    PoundForceFeetPerFoot = "PoundForceFootPerFoot",
     /** */
-    KilogramForceMillimetersPerMeter,
+    KilogramForceMillimetersPerMeter = "KilogramForceMillimeterPerMeter",
     /** */
-    KilogramForceCentimetersPerMeter,
+    KilogramForceCentimetersPerMeter = "KilogramForceCentimeterPerMeter",
     /** */
-    KilogramForceMetersPerMeter,
+    KilogramForceMetersPerMeter = "KilogramForceMeterPerMeter",
     /** */
-    TonneForceMillimetersPerMeter,
+    TonneForceMillimetersPerMeter = "TonneForceMillimeterPerMeter",
     /** */
-    TonneForceCentimetersPerMeter,
+    TonneForceCentimetersPerMeter = "TonneForceCentimeterPerMeter",
     /** */
-    TonneForceMetersPerMeter,
+    TonneForceMetersPerMeter = "TonneForceMeterPerMeter",
     /** */
-    KilonewtonMillimetersPerMeter,
+    KilonewtonMillimetersPerMeter = "KilonewtonMillimeterPerMeter",
     /** */
-    MeganewtonMillimetersPerMeter,
+    MeganewtonMillimetersPerMeter = "MeganewtonMillimeterPerMeter",
     /** */
-    KilonewtonCentimetersPerMeter,
+    KilonewtonCentimetersPerMeter = "KilonewtonCentimeterPerMeter",
     /** */
-    MeganewtonCentimetersPerMeter,
+    MeganewtonCentimetersPerMeter = "MeganewtonCentimeterPerMeter",
     /** */
-    KilonewtonMetersPerMeter,
+    KilonewtonMetersPerMeter = "KilonewtonMeterPerMeter",
     /** */
-    MeganewtonMetersPerMeter,
+    MeganewtonMetersPerMeter = "MeganewtonMeterPerMeter",
     /** */
-    KilopoundForceInchesPerFoot,
+    KilopoundForceInchesPerFoot = "KilopoundForceInchPerFoot",
     /** */
-    MegapoundForceInchesPerFoot,
+    MegapoundForceInchesPerFoot = "MegapoundForceInchPerFoot",
     /** */
-    KilopoundForceFeetPerFoot,
+    KilopoundForceFeetPerFoot = "KilopoundForceFootPerFoot",
     /** */
-    MegapoundForceFeetPerFoot
+    MegapoundForceFeetPerFoot = "MegapoundForceFootPerFoot"
 }
 
 /** The magnitude of torque per unit length. */

--- a/src/turbidity.g.ts
+++ b/src/turbidity.g.ts
@@ -1,7 +1,7 @@
 /** TurbidityUnits enumeration */
 export enum TurbidityUnits {
     /** */
-    NTU
+    NTU = "NTU"
 }
 
 /** Turbidity is the cloudiness or haziness of a fluid caused by large numbers of individual particles that are generally invisible to the naked eye, similar to smoke in air. The measurement of turbidity is a key test of water quality. */

--- a/src/vitamina.g.ts
+++ b/src/vitamina.g.ts
@@ -1,7 +1,7 @@
 /** VitaminAUnits enumeration */
 export enum VitaminAUnits {
     /** */
-    InternationalUnits
+    InternationalUnits = "InternationalUnit"
 }
 
 /** Vitamin A: 1 IU is the biological equivalent of 0.3 µg retinol, or of 0.6 µg beta-carotene. */

--- a/src/volume.g.ts
+++ b/src/volume.g.ts
@@ -1,113 +1,113 @@
 /** VolumeUnits enumeration */
 export enum VolumeUnits {
     /** */
-    Liters,
+    Liters = "Liter",
     /** */
-    CubicMeters,
+    CubicMeters = "CubicMeter",
     /** */
-    CubicKilometers,
+    CubicKilometers = "CubicKilometer",
     /** */
-    CubicHectometers,
+    CubicHectometers = "CubicHectometer",
     /** */
-    CubicDecimeters,
+    CubicDecimeters = "CubicDecimeter",
     /** */
-    CubicCentimeters,
+    CubicCentimeters = "CubicCentimeter",
     /** */
-    CubicMillimeters,
+    CubicMillimeters = "CubicMillimeter",
     /** */
-    CubicMicrometers,
+    CubicMicrometers = "CubicMicrometer",
     /** */
-    CubicMiles,
+    CubicMiles = "CubicMile",
     /** */
-    CubicYards,
+    CubicYards = "CubicYard",
     /** */
-    CubicFeet,
+    CubicFeet = "CubicFoot",
     /** */
-    CubicInches,
+    CubicInches = "CubicInch",
     /** The British imperial gallon (frequently called simply "gallon") is defined as exactly 4.54609 litres. */
-    ImperialGallons,
+    ImperialGallons = "ImperialGallon",
     /** */
-    ImperialOunces,
+    ImperialOunces = "ImperialOunce",
     /** The US liquid gallon (frequently called simply "gallon") is legally defined as 231 cubic inches, which is exactly 3.785411784 litres. */
-    UsGallons,
+    UsGallons = "UsGallon",
     /** */
-    UsOunces,
+    UsOunces = "UsOunce",
     /** */
-    UsTablespoons,
+    UsTablespoons = "UsTablespoon",
     /** */
-    AuTablespoons,
+    AuTablespoons = "AuTablespoon",
     /** */
-    UkTablespoons,
+    UkTablespoons = "UkTablespoon",
     /** */
-    MetricTeaspoons,
+    MetricTeaspoons = "MetricTeaspoon",
     /** */
-    UsTeaspoons,
+    UsTeaspoons = "UsTeaspoon",
     /** */
-    MetricCups,
+    MetricCups = "MetricCup",
     /** */
-    UsCustomaryCups,
+    UsCustomaryCups = "UsCustomaryCup",
     /** */
-    UsLegalCups,
+    UsLegalCups = "UsLegalCup",
     /** */
-    OilBarrels,
+    OilBarrels = "OilBarrel",
     /** */
-    UsBeerBarrels,
+    UsBeerBarrels = "UsBeerBarrel",
     /** */
-    ImperialBeerBarrels,
+    ImperialBeerBarrels = "ImperialBeerBarrel",
     /** */
-    UsQuarts,
+    UsQuarts = "UsQuart",
     /** */
-    ImperialQuarts,
+    ImperialQuarts = "ImperialQuart",
     /** */
-    UsPints,
+    UsPints = "UsPint",
     /** */
-    AcreFeet,
+    AcreFeet = "AcreFoot",
     /** */
-    ImperialPints,
+    ImperialPints = "ImperialPint",
     /** */
-    BoardFeet,
+    BoardFeet = "BoardFoot",
     /** */
-    Nanoliters,
+    Nanoliters = "Nanoliter",
     /** */
-    Microliters,
+    Microliters = "Microliter",
     /** */
-    Milliliters,
+    Milliliters = "Milliliter",
     /** */
-    Centiliters,
+    Centiliters = "Centiliter",
     /** */
-    Deciliters,
+    Deciliters = "Deciliter",
     /** */
-    Decaliters,
+    Decaliters = "Decaliter",
     /** */
-    Hectoliters,
+    Hectoliters = "Hectoliter",
     /** */
-    Kiloliters,
+    Kiloliters = "Kiloliter",
     /** */
-    Megaliters,
+    Megaliters = "Megaliter",
     /** */
-    HectocubicMeters,
+    HectocubicMeters = "HectocubicMeter",
     /** */
-    KilocubicMeters,
+    KilocubicMeters = "KilocubicMeter",
     /** */
-    HectocubicFeet,
+    HectocubicFeet = "HectocubicFoot",
     /** */
-    KilocubicFeet,
+    KilocubicFeet = "KilocubicFoot",
     /** */
-    MegacubicFeet,
+    MegacubicFeet = "MegacubicFoot",
     /** */
-    KiloimperialGallons,
+    KiloimperialGallons = "KiloimperialGallon",
     /** */
-    MegaimperialGallons,
+    MegaimperialGallons = "MegaimperialGallon",
     /** */
-    DecausGallons,
+    DecausGallons = "DecausGallon",
     /** */
-    DeciusGallons,
+    DeciusGallons = "DeciusGallon",
     /** */
-    HectousGallons,
+    HectousGallons = "HectousGallon",
     /** */
-    KilousGallons,
+    KilousGallons = "KilousGallon",
     /** */
-    MegausGallons
+    MegausGallons = "MegausGallon"
 }
 
 /** Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces. */

--- a/src/volumeconcentration.g.ts
+++ b/src/volumeconcentration.g.ts
@@ -1,45 +1,45 @@
 /** VolumeConcentrationUnits enumeration */
 export enum VolumeConcentrationUnits {
     /** */
-    DecimalFractions,
+    DecimalFractions = "DecimalFraction",
     /** */
-    LitersPerLiter,
+    LitersPerLiter = "LitersPerLiter",
     /** */
-    LitersPerMililiter,
+    LitersPerMililiter = "LitersPerMililiter",
     /** */
-    Percent,
+    Percent = "Percent",
     /** */
-    PartsPerThousand,
+    PartsPerThousand = "PartPerThousand",
     /** */
-    PartsPerMillion,
+    PartsPerMillion = "PartPerMillion",
     /** */
-    PartsPerBillion,
+    PartsPerBillion = "PartPerBillion",
     /** */
-    PartsPerTrillion,
+    PartsPerTrillion = "PartPerTrillion",
     /** */
-    PicolitersPerLiter,
+    PicolitersPerLiter = "PicolitersPerLiter",
     /** */
-    NanolitersPerLiter,
+    NanolitersPerLiter = "NanolitersPerLiter",
     /** */
-    MicrolitersPerLiter,
+    MicrolitersPerLiter = "MicrolitersPerLiter",
     /** */
-    MillilitersPerLiter,
+    MillilitersPerLiter = "MillilitersPerLiter",
     /** */
-    CentilitersPerLiter,
+    CentilitersPerLiter = "CentilitersPerLiter",
     /** */
-    DecilitersPerLiter,
+    DecilitersPerLiter = "DecilitersPerLiter",
     /** */
-    PicolitersPerMililiter,
+    PicolitersPerMililiter = "PicolitersPerMililiter",
     /** */
-    NanolitersPerMililiter,
+    NanolitersPerMililiter = "NanolitersPerMililiter",
     /** */
-    MicrolitersPerMililiter,
+    MicrolitersPerMililiter = "MicrolitersPerMililiter",
     /** */
-    MillilitersPerMililiter,
+    MillilitersPerMililiter = "MillilitersPerMililiter",
     /** */
-    CentilitersPerMililiter,
+    CentilitersPerMililiter = "CentilitersPerMililiter",
     /** */
-    DecilitersPerMililiter
+    DecilitersPerMililiter = "DecilitersPerMililiter"
 }
 
 /** The volume concentration (not to be confused with volume fraction) is defined as the volume of a constituent divided by the total volume of the mixture. */

--- a/src/volumeflow.g.ts
+++ b/src/volumeflow.g.ts
@@ -1,155 +1,155 @@
 /** VolumeFlowUnits enumeration */
 export enum VolumeFlowUnits {
     /** */
-    CubicMetersPerSecond,
+    CubicMetersPerSecond = "CubicMeterPerSecond",
     /** */
-    CubicMetersPerMinute,
+    CubicMetersPerMinute = "CubicMeterPerMinute",
     /** */
-    CubicMetersPerHour,
+    CubicMetersPerHour = "CubicMeterPerHour",
     /** */
-    CubicMetersPerDay,
+    CubicMetersPerDay = "CubicMeterPerDay",
     /** */
-    CubicFeetPerSecond,
+    CubicFeetPerSecond = "CubicFootPerSecond",
     /** */
-    CubicFeetPerMinute,
+    CubicFeetPerMinute = "CubicFootPerMinute",
     /** */
-    CubicFeetPerHour,
+    CubicFeetPerHour = "CubicFootPerHour",
     /** */
-    CubicYardsPerSecond,
+    CubicYardsPerSecond = "CubicYardPerSecond",
     /** */
-    CubicYardsPerMinute,
+    CubicYardsPerMinute = "CubicYardPerMinute",
     /** */
-    CubicYardsPerHour,
+    CubicYardsPerHour = "CubicYardPerHour",
     /** */
-    CubicYardsPerDay,
+    CubicYardsPerDay = "CubicYardPerDay",
     /** */
-    MillionUsGallonsPerDay,
+    MillionUsGallonsPerDay = "MillionUsGallonPerDay",
     /** */
-    UsGallonsPerDay,
+    UsGallonsPerDay = "UsGallonPerDay",
     /** */
-    LitersPerSecond,
+    LitersPerSecond = "LiterPerSecond",
     /** */
-    LitersPerMinute,
+    LitersPerMinute = "LiterPerMinute",
     /** */
-    LitersPerHour,
+    LitersPerHour = "LiterPerHour",
     /** */
-    LitersPerDay,
+    LitersPerDay = "LiterPerDay",
     /** */
-    UsGallonsPerSecond,
+    UsGallonsPerSecond = "UsGallonPerSecond",
     /** */
-    UsGallonsPerMinute,
+    UsGallonsPerMinute = "UsGallonPerMinute",
     /** */
-    UkGallonsPerDay,
+    UkGallonsPerDay = "UkGallonPerDay",
     /** */
-    UkGallonsPerHour,
+    UkGallonsPerHour = "UkGallonPerHour",
     /** */
-    UkGallonsPerMinute,
+    UkGallonsPerMinute = "UkGallonPerMinute",
     /** */
-    UkGallonsPerSecond,
+    UkGallonsPerSecond = "UkGallonPerSecond",
     /** */
-    KilousGallonsPerMinute,
+    KilousGallonsPerMinute = "KilousGallonPerMinute",
     /** */
-    UsGallonsPerHour,
+    UsGallonsPerHour = "UsGallonPerHour",
     /** */
-    CubicDecimetersPerMinute,
+    CubicDecimetersPerMinute = "CubicDecimeterPerMinute",
     /** */
-    OilBarrelsPerDay,
+    OilBarrelsPerDay = "OilBarrelPerDay",
     /** */
-    OilBarrelsPerMinute,
+    OilBarrelsPerMinute = "OilBarrelPerMinute",
     /** */
-    OilBarrelsPerHour,
+    OilBarrelsPerHour = "OilBarrelPerHour",
     /** */
-    OilBarrelsPerSecond,
+    OilBarrelsPerSecond = "OilBarrelPerSecond",
     /** */
-    CubicMillimetersPerSecond,
+    CubicMillimetersPerSecond = "CubicMillimeterPerSecond",
     /** */
-    AcreFeetPerSecond,
+    AcreFeetPerSecond = "AcreFootPerSecond",
     /** */
-    AcreFeetPerMinute,
+    AcreFeetPerMinute = "AcreFootPerMinute",
     /** */
-    AcreFeetPerHour,
+    AcreFeetPerHour = "AcreFootPerHour",
     /** */
-    AcreFeetPerDay,
+    AcreFeetPerDay = "AcreFootPerDay",
     /** */
-    CubicCentimetersPerMinute,
+    CubicCentimetersPerMinute = "CubicCentimeterPerMinute",
     /** */
-    MegausGallonsPerDay,
+    MegausGallonsPerDay = "MegausGallonPerDay",
     /** */
-    NanolitersPerSecond,
+    NanolitersPerSecond = "NanoliterPerSecond",
     /** */
-    MicrolitersPerSecond,
+    MicrolitersPerSecond = "MicroliterPerSecond",
     /** */
-    MillilitersPerSecond,
+    MillilitersPerSecond = "MilliliterPerSecond",
     /** */
-    CentilitersPerSecond,
+    CentilitersPerSecond = "CentiliterPerSecond",
     /** */
-    DecilitersPerSecond,
+    DecilitersPerSecond = "DeciliterPerSecond",
     /** */
-    DecalitersPerSecond,
+    DecalitersPerSecond = "DecaliterPerSecond",
     /** */
-    HectolitersPerSecond,
+    HectolitersPerSecond = "HectoliterPerSecond",
     /** */
-    KilolitersPerSecond,
+    KilolitersPerSecond = "KiloliterPerSecond",
     /** */
-    MegalitersPerSecond,
+    MegalitersPerSecond = "MegaliterPerSecond",
     /** */
-    NanolitersPerMinute,
+    NanolitersPerMinute = "NanoliterPerMinute",
     /** */
-    MicrolitersPerMinute,
+    MicrolitersPerMinute = "MicroliterPerMinute",
     /** */
-    MillilitersPerMinute,
+    MillilitersPerMinute = "MilliliterPerMinute",
     /** */
-    CentilitersPerMinute,
+    CentilitersPerMinute = "CentiliterPerMinute",
     /** */
-    DecilitersPerMinute,
+    DecilitersPerMinute = "DeciliterPerMinute",
     /** */
-    DecalitersPerMinute,
+    DecalitersPerMinute = "DecaliterPerMinute",
     /** */
-    HectolitersPerMinute,
+    HectolitersPerMinute = "HectoliterPerMinute",
     /** */
-    KilolitersPerMinute,
+    KilolitersPerMinute = "KiloliterPerMinute",
     /** */
-    MegalitersPerMinute,
+    MegalitersPerMinute = "MegaliterPerMinute",
     /** */
-    NanolitersPerHour,
+    NanolitersPerHour = "NanoliterPerHour",
     /** */
-    MicrolitersPerHour,
+    MicrolitersPerHour = "MicroliterPerHour",
     /** */
-    MillilitersPerHour,
+    MillilitersPerHour = "MilliliterPerHour",
     /** */
-    CentilitersPerHour,
+    CentilitersPerHour = "CentiliterPerHour",
     /** */
-    DecilitersPerHour,
+    DecilitersPerHour = "DeciliterPerHour",
     /** */
-    DecalitersPerHour,
+    DecalitersPerHour = "DecaliterPerHour",
     /** */
-    HectolitersPerHour,
+    HectolitersPerHour = "HectoliterPerHour",
     /** */
-    KilolitersPerHour,
+    KilolitersPerHour = "KiloliterPerHour",
     /** */
-    MegalitersPerHour,
+    MegalitersPerHour = "MegaliterPerHour",
     /** */
-    NanolitersPerDay,
+    NanolitersPerDay = "NanoliterPerDay",
     /** */
-    MicrolitersPerDay,
+    MicrolitersPerDay = "MicroliterPerDay",
     /** */
-    MillilitersPerDay,
+    MillilitersPerDay = "MilliliterPerDay",
     /** */
-    CentilitersPerDay,
+    CentilitersPerDay = "CentiliterPerDay",
     /** */
-    DecilitersPerDay,
+    DecilitersPerDay = "DeciliterPerDay",
     /** */
-    DecalitersPerDay,
+    DecalitersPerDay = "DecaliterPerDay",
     /** */
-    HectolitersPerDay,
+    HectolitersPerDay = "HectoliterPerDay",
     /** */
-    KilolitersPerDay,
+    KilolitersPerDay = "KiloliterPerDay",
     /** */
-    MegalitersPerDay,
+    MegalitersPerDay = "MegaliterPerDay",
     /** */
-    MegaukGallonsPerDay,
+    MegaukGallonsPerDay = "MegaukGallonPerDay",
     /** */
-    MegaukGallonsPerSecond
+    MegaukGallonsPerSecond = "MegaukGallonPerSecond"
 }
 
 /** In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m³/s (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft³/s (cubic feet per second). It is usually represented by the symbol Q. */

--- a/src/volumeflowperarea.g.ts
+++ b/src/volumeflowperarea.g.ts
@@ -1,9 +1,9 @@
 /** VolumeFlowPerAreaUnits enumeration */
 export enum VolumeFlowPerAreaUnits {
     /** */
-    CubicMetersPerSecondPerSquareMeter,
+    CubicMetersPerSecondPerSquareMeter = "CubicMeterPerSecondPerSquareMeter",
     /** */
-    CubicFeetPerMinutePerSquareFoot
+    CubicFeetPerMinutePerSquareFoot = "CubicFootPerMinutePerSquareFoot"
 }
 
 /** The volumetric flow rate per area is the volume of fluid which passes through a given unit surface area per unit time. */

--- a/src/volumeperlength.g.ts
+++ b/src/volumeperlength.g.ts
@@ -1,23 +1,23 @@
 /** VolumePerLengthUnits enumeration */
 export enum VolumePerLengthUnits {
     /** */
-    CubicMetersPerMeter,
+    CubicMetersPerMeter = "CubicMeterPerMeter",
     /** */
-    LitersPerMeter,
+    LitersPerMeter = "LiterPerMeter",
     /** */
-    LitersPerKilometer,
+    LitersPerKilometer = "LiterPerKilometer",
     /** */
-    LitersPerMillimeter,
+    LitersPerMillimeter = "LiterPerMillimeter",
     /** */
-    OilBarrelsPerFoot,
+    OilBarrelsPerFoot = "OilBarrelPerFoot",
     /** */
-    CubicYardsPerFoot,
+    CubicYardsPerFoot = "CubicYardPerFoot",
     /** */
-    CubicYardsPerUsSurveyFoot,
+    CubicYardsPerUsSurveyFoot = "CubicYardPerUsSurveyFoot",
     /** */
-    UsGallonsPerMile,
+    UsGallonsPerMile = "UsGallonPerMile",
     /** */
-    ImperialGallonsPerMile
+    ImperialGallonsPerMile = "ImperialGallonPerMile"
 }
 
 /** Volume, typically of fluid, that a container can hold within a unit of length. */

--- a/src/volumetricheatcapacity.g.ts
+++ b/src/volumetricheatcapacity.g.ts
@@ -1,23 +1,23 @@
 /** VolumetricHeatCapacityUnits enumeration */
 export enum VolumetricHeatCapacityUnits {
     /** */
-    JoulesPerCubicMeterKelvin,
+    JoulesPerCubicMeterKelvin = "JoulePerCubicMeterKelvin",
     /** */
-    JoulesPerCubicMeterDegreeCelsius,
+    JoulesPerCubicMeterDegreeCelsius = "JoulePerCubicMeterDegreeCelsius",
     /** */
-    CaloriesPerCubicCentimeterDegreeCelsius,
+    CaloriesPerCubicCentimeterDegreeCelsius = "CaloriePerCubicCentimeterDegreeCelsius",
     /** */
-    BtusPerCubicFootDegreeFahrenheit,
+    BtusPerCubicFootDegreeFahrenheit = "BtuPerCubicFootDegreeFahrenheit",
     /** */
-    KilojoulesPerCubicMeterKelvin,
+    KilojoulesPerCubicMeterKelvin = "KilojoulePerCubicMeterKelvin",
     /** */
-    MegajoulesPerCubicMeterKelvin,
+    MegajoulesPerCubicMeterKelvin = "MegajoulePerCubicMeterKelvin",
     /** */
-    KilojoulesPerCubicMeterDegreeCelsius,
+    KilojoulesPerCubicMeterDegreeCelsius = "KilojoulePerCubicMeterDegreeCelsius",
     /** */
-    MegajoulesPerCubicMeterDegreeCelsius,
+    MegajoulesPerCubicMeterDegreeCelsius = "MegajoulePerCubicMeterDegreeCelsius",
     /** */
-    KilocaloriesPerCubicCentimeterDegreeCelsius
+    KilocaloriesPerCubicCentimeterDegreeCelsius = "KilocaloriePerCubicCentimeterDegreeCelsius"
 }
 
 /** The volumetric heat capacity is the amount of energy that must be added, in the form of heat, to one unit of volume of the material in order to cause an increase of one unit in its temperature. */

--- a/src/warpingmomentofinertia.g.ts
+++ b/src/warpingmomentofinertia.g.ts
@@ -1,17 +1,17 @@
 /** WarpingMomentOfInertiaUnits enumeration */
 export enum WarpingMomentOfInertiaUnits {
     /** */
-    MetersToTheSixth,
+    MetersToTheSixth = "MeterToTheSixth",
     /** */
-    DecimetersToTheSixth,
+    DecimetersToTheSixth = "DecimeterToTheSixth",
     /** */
-    CentimetersToTheSixth,
+    CentimetersToTheSixth = "CentimeterToTheSixth",
     /** */
-    MillimetersToTheSixth,
+    MillimetersToTheSixth = "MillimeterToTheSixth",
     /** */
-    FeetToTheSixth,
+    FeetToTheSixth = "FootToTheSixth",
     /** */
-    InchesToTheSixth
+    InchesToTheSixth = "InchToTheSixth"
 }
 
 /** A geometric property of an area that is used to determine the warping stress. */


### PR DESCRIPTION
The value is meant to be the exact as the C# UnitsNet enums (e.g. `LengthUnit.Meter`) see #29 for the motivation.

The key of the enum is still in plural convention to keep backward compatibility.

Despite that for any normal use of the package, this change should be fully transparent, still updating the major version in case some use-case will be broken by this modification. 
