### PR TITLE
fix: add GitHub token auth to prevent API rate limit failures

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,8 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Build & Test 🔧
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           yarn generate
           yarn test

--- a/generator-scripts/src/units-definitions-fetcher.ts
+++ b/generator-scripts/src/units-definitions-fetcher.ts
@@ -5,9 +5,12 @@ import fs from 'fs-extra';
 import path from 'path';
 import JSON5 from 'json5';
 
+const githubToken = process.env.GITHUB_TOKEN;
+
 const githubOptions = {
     headers: {
         'user-agent': 'PostmanRuntime/7.20.1',
+        ...(githubToken ? { 'Authorization': `token ${githubToken}` } : {}),
     },
 };
 
@@ -62,7 +65,10 @@ export function fetchUnitsDefinitions(repoOwnerAndName: string): UnitTypeDefinit
         if (!definitionFiles) {
             const response = request('GET', directoryUrl, githubOptions);
 
-            const body = JSON.parse(response.body.toString('utf-8')) as unknown as [];
+            const body = JSON.parse(response.body.toString('utf-8'));
+            if (!Array.isArray(body)) {
+                throw new Error(`Unexpected response from GitHub API: ${JSON.stringify(body)}`);
+            }
             definitionFiles = body.map((file: any) => file.name);
             keepDefinitionFile('files.json', definitionFiles);
         }


### PR DESCRIPTION
## Summary
- Pass `GITHUB_TOKEN` as `Authorization` header when fetching unit definitions from GitHub API
- Add `Array.isArray` guard with descriptive error when API returns non-array (e.g. rate limit error object)
- Wire `GITHUB_TOKEN` into CI build step env so the token is available during `yarn generate`

## Root Cause
Unauthenticated requests to `api.github.com` hit rate limits and return `{ message: "API rate limit exceeded", ... }` instead of an array. The code cast the response to `[]` and called `.map()` on it, throwing `TypeError: body.map is not a function`.

## Test plan
- [ ] Trigger `workflow_dispatch` on the PR branch and verify build passes
- [ ] Confirm generator fetches unit definitions without rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)