### PR TITLE
fix: switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,6 +61,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -99,9 +102,7 @@ jobs:
           commit_message: Update to version ${{ steps.update_version.outputs.VERSION }} [skip-ci]
 
       - name: Publish package on NPM 📦
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to `release` job
- Publish via `npm publish --provenance --access public` (OIDC) instead of `NODE_AUTH_TOKEN`/`NPM_TOKEN` secret

## Root Cause
[Run 30169598454](https://github.com/haimkastner/unitsnet-js/actions/runs/30169598454/job/89708425987) failed with `404 Not Found` on `npm publish` — `NPM_TOKEN` secret invalid/expired. Package's npm page shows Trusted Publisher (OIDC) already configured for this repo/workflow, so a token isn't needed at all — switch to OIDC-based provenance publishing.

## Test plan
- [ ] Merge to master and verify `release` job publishes successfully without `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)