### PR TITLE
fix(ci): use Node 24 in release job for OIDC trusted publishing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,9 +66,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: '22.x'
+          # Node 24 ships npm >= 11.5.1, required for OIDC trusted publishing
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Prepare dependencies


### PR DESCRIPTION
## Problem

Publish failed on [run 30170320628](https://github.com/haimkastner/unitsnet-js/actions/runs/30170320628/job/89710307526):

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/unitsnet-js - Not found
npm error 404  'unitsnet-js@4.0.9' is not in this registry.
```

The npm trusted publisher is configured correctly (repo `haimkastner/unitsnet-js`, workflow `nodejs.yml`), and the job already has `id-token: write` plus `registry-url`. The blocker is the npm version:

```
release  Run actions/setup-node@v5   node: v22.23.1
release  Run actions/setup-node@v5   npm: 10.9.8
```

OIDC trusted publishing requires **npm >= 11.5.1**. npm 10.x never performs the token exchange, so `npm publish` ran unauthenticated and the registry returned a 404 (masked 403).

## Fix

Release job now uses Node 24, which ships npm 11.6.x. Also bumps `actions/setup-node` to v5 (v4 targets the deprecated Node 20 runtime).

## Note

Version 4.0.9 was already committed and pushed to master by the "Increase Version" step before the publish failed, so it stays unpublished — the next release run will bump to the following version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)